### PR TITLE
[minor] fix test warnings on here-doc syntax

### DIFF
--- a/test/instrumentation-tests.t/attributes.t
+++ b/test/instrumentation-tests.t/attributes.t
@@ -99,7 +99,7 @@ Create a test.ml file with a module attribute
   >   let greet () = print_endline ("Hello," ^ " world!")
   > end
   > let () = T.greet()
-
+  > EOF
 
 Preprocess, check that attribute triggers deprecation error
 

--- a/test/instrumentation-tests.t/match-omit-case.t
+++ b/test/instrumentation-tests.t/match-omit-case.t
@@ -519,7 +519,7 @@ A test with exceptions:
   > my_find h 1 |> print_endline;;
   > my_find h 2 |> print_endline;;
   > my_find h 3 |> print_endline;;
-
+  > EOF
 
   $ export MUTAML_SEED=896745231
 


### PR DESCRIPTION
> warning: here-document at line 1 delimited by end-of-file (wanted `EOF')
