### PR TITLE
Fix the evaluation order of arithmetic operands

### DIFF
--- a/src/ppx/mutaml_ppx.ml
+++ b/src/ppx/mutaml_ppx.ml
@@ -254,10 +254,10 @@ class mutate_mapper (rs : RS.t) =
     (* problem:  duplication between the recursively mutated e' (exp1 + exp2')
                  and the original e (exp + exp')
        solution: let-name locally:
-                 let __mutaml_tmp25 = exp1 in
-                 let __mutaml_tmp26 = exp2 in
+                 let __mutaml_tmp25 = exp2 in
+                 let __mutaml_tmp26 = exp1 in
                  if __MUTAML_MUTANT__ = Some 17
-                 then __mutaml_tmp25 - __mutaml_tmp26
+                 then __mutaml_tmp26 - __mutaml_tmp26
                  else __mutaml_tmp25 + __mutaml_tmp26  *)
     match e with
     (* A special case mutations: omit 1+ *)
@@ -290,9 +290,10 @@ class mutate_mapper (rs : RS.t) =
           | _ ->
             failwith ("mutaml_ppx, mutate_arithmetic: found some other operator case: " ^  (string_of_exp op))
         )} in
-         let k1, tmp_var1 = self#let_bind ~loc:exp1.pexp_loc (self#expression ctx exp1) in
+         (* Note: we bind exp2 before exp1 to preserve the current (unspecified) OCaml evaluation order. *)
          let k2, tmp_var2 = self#let_bind ~loc:exp2.pexp_loc (self#expression ctx exp2) in
-         k1 (k2 (self#mutaml_mutant ctx loc
+         let k1, tmp_var1 = self#let_bind ~loc:exp1.pexp_loc (self#expression ctx exp1) in
+         k2 (k1 (self#mutaml_mutant ctx loc
                    { e with pexp_desc = [%expr [%e mut_op] [%e tmp_var1] [%e tmp_var2]].pexp_desc }
                    { e with pexp_desc = [%expr [%e op]     [%e tmp_var1] [%e tmp_var2]].pexp_desc }
                          (string_of_exp [%expr [%e mut_op] [%e exp1]     [%e exp2]])))

--- a/test/instrumentation-tests.t/attributes.t
+++ b/test/instrumentation-tests.t/attributes.t
@@ -99,7 +99,7 @@ Create a test.ml file with a module attribute
   >   let greet () = print_endline ("Hello," ^ " world!")
   > end
   > let () = T.greet()
-
+  > EOF
 
 Preprocess, check that attribute triggers deprecation error
 

--- a/test/instrumentation-tests.t/match-omit-case.t
+++ b/test/instrumentation-tests.t/match-omit-case.t
@@ -519,7 +519,7 @@ A test with exceptions:
   > my_find h 1 |> print_endline;;
   > my_find h 2 |> print_endline;;
   > my_find h 3 |> print_endline;;
-
+  > EOF
 
   $ export MUTAML_SEED=896745231
 


### PR DESCRIPTION
Note: I think that a simpler translation of `e1 + e2`, which would avoid issues with evaluation order as well, would be

```
(if <mutate> then (-) else (+)) e1 e2
```