### PR TITLE
Configurable diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ if [instrumentation is enabled via another `dune-workspace` build context](https
   command-line option `-build-context`)
 
 
+Currently `mutaml-report` uses `diff --color -u` as its default
+command to print `diff`s. It falls back to `diff -u` when the
+environment variable `CI` is `true`. The used command can also be
+configured an environment variable:
+
+- `MUTAML_DIFF_COMMAND` - the command and options to use instead,
+  e.g. `MUTAML_DIFF_COMMAND="diff -U 5"` will disable colored outputs
+  and add 5 lines of unified context. Mutaml expects the specified
+  command to support `--label` options.
+
+
 
 Status
 ------

--- a/test/testproj-1-module.t/run.t
+++ b/test/testproj-1-module.t/run.t
@@ -340,6 +340,78 @@ And try the -no-diff option without providing an explicit file name:
 --------------------------------------------------------------------------------
 
 
+And try with the MUTAML_DIFF_COMMAND environment variable:
+
+  $ export MUTAML_DIFF_COMMAND="diff -U 2"
+  $ mutaml-report
+  Attempting to read from mutaml-report.json...
+  
+  Mutaml report summary:
+  ----------------------
+  
+   target                          #mutations      #failed      #timeouts      #passed 
+   -------------------------------------------------------------------------------------
+   lib.ml                                13      84.6%   11     0.0%    0    15.4%    2
+   =====================================================================================
+  
+  Mutation programs passing the test suite:
+  -----------------------------------------
+  
+  Mutation "lib.ml-mutant6" passed (see "_mutations/lib.ml-mutant6.output"):
+  
+  --- lib.ml
+  +++ lib.ml-mutant6
+  @@ -22,5 +22,5 @@
+   let pi total =
+     let rec loop n inside =
+  -    if n = 0 then
+  +    if n = 1 then
+         4. *. (float_of_int inside /. float_of_int total)
+       else
+  
+  ---------------------------------------------------------------------------
+  
+  Mutation "lib.ml-mutant12" passed (see "_mutations/lib.ml-mutant12.output"):
+  
+  --- lib.ml
+  +++ lib.ml-mutant12
+  @@ -31,3 +31,3 @@
+         else loop (n-1) (inside)
+     in
+  -  loop total 0
+  +  loop total 1
+  
+  ---------------------------------------------------------------------------
+  
+
+
+Also check that MUTAML_DIFF_COMMAND doesn't affect -no-diff:
+
+  $ mutaml-report -no-diff
+  Attempting to read from mutaml-report.json...
+  
+  Mutaml report summary:
+  ----------------------
+  
+   target                          #mutations      #failed      #timeouts      #passed 
+   -------------------------------------------------------------------------------------
+   lib.ml                                13      84.6%   11     0.0%    0    15.4%    2
+   =====================================================================================
+  
+  Mutation programs passing the test suite:
+  -----------------------------------------
+  
+  Mutation "lib.ml-mutant6" passed (see "_mutations/lib.ml-mutant6.output")
+  Mutation "lib.ml-mutant12" passed (see "_mutations/lib.ml-mutant12.output")
+
+
+Now clean-up MUTAML_DIFF_COMMAND again
+
+  $ unset MUTAML_DIFF_COMMAND
+
+--------------------------------------------------------------------------------
+
+
 Now move file to a different name and retry the -no-diff option with the new name:
 
   $ mv mutaml-report.json some-report-name.json


### PR DESCRIPTION
This PR fixes #8 by adding support for an environment variable `MUTAML_DIFF_COMMAND` to configure how `mutaml-report` prints its `diff`s.

The functionality should be generally useful - and furthermore help please the CI-gods, where Alpine's usage of Busybox means it doesn't understand the `diff --color` option:
  https://ocaml.ci.dev/github/jmid/mutaml/commit/4a3e83feff4e3f7c2e0d9c7fa3caacc4b7c2dcaa/variant/alpine-3.17-5.0_opam-2.1