### PR TITLE
macOS test adjustments

### DIFF
--- a/test/instrumentation-tests.t/filter_dune_build.sh
+++ b/test/instrumentation-tests.t/filter_dune_build.sh
@@ -4,6 +4,6 @@
 #   filter [@@@ocaml.ppx.context whitespace {  0-or-more not-close-brace-chars }]
 #   and normalize file system paths
 dune build $@ 2>&1 | \
-    sed  -E 'H;1h;$!d;x;s/\[@@@ocaml\.ppx\.context\s+\{[^}]*\}\]//g' | \
+    sed  -E 'H;1h;$!d;x;s/\[@@@ocaml\.ppx\.context\n\ \ \{[^}]*\}\]//g' | \
     sed 's/home[^ ]*bin\//some\/path\/...\/bin\//' | \
     sed 's/Users[^ ]*bin\//some\/path\/...\/bin\//'

--- a/test/issue-newlines.t/filter_dune_build.sh
+++ b/test/issue-newlines.t/filter_dune_build.sh
@@ -4,6 +4,6 @@
 #   filter [@@@ocaml.ppx.context whitespace {  0-or-more not-close-brace-chars }]
 #   and normalize file system paths
 dune build $@ 2>&1 | \
-    sed  -E 'H;1h;$!d;x;s/\[@@@ocaml\.ppx\.context\s+\{[^}]*\}\]//g' | \
+    sed  -E 'H;1h;$!d;x;s/\[@@@ocaml\.ppx\.context\n\ \ \{[^}]*\}\]//g' | \
     sed 's/home[^ ]*bin\//some\/path\/...\/bin\//' | \
     sed 's/Users[^ ]*bin\//some\/path\/...\/bin\//'

--- a/test/testproj-1-module.t/run.t
+++ b/test/testproj-1-module.t/run.t
@@ -36,6 +36,9 @@ Check that files were created as expected:
   main.ml
   ounittest.ml
 
+Set diff command to make sure this test also works under macOS
+  $ export MUTAML_DIFF_COMMAND="diff -u"
+
 Set seed and (full) mutation rate as environment variables, for repeatability
   $ export MUTAML_SEED=896745231
   $ export MUTAML_MUT_RATE=100
@@ -340,7 +343,7 @@ And try the -no-diff option without providing an explicit file name:
 --------------------------------------------------------------------------------
 
 
-And try with the MUTAML_DIFF_COMMAND environment variable:
+And try with a different MUTAML_DIFF_COMMAND environment variable:
 
   $ export MUTAML_DIFF_COMMAND="diff -U 2"
   $ mutaml-report
@@ -405,9 +408,9 @@ Also check that MUTAML_DIFF_COMMAND doesn't affect -no-diff:
   Mutation "lib.ml-mutant12" passed (see "_mutations/lib.ml-mutant12.output")
 
 
-Now clean-up MUTAML_DIFF_COMMAND again
+Now clean-up MUTAML_DIFF_COMMAND again to default again
 
-  $ unset MUTAML_DIFF_COMMAND
+  $ export MUTAML_DIFF_COMMAND="diff -u"
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This little PR makes two changes to make the test suite run under macOS CI as well as on the command line with 
```
  MUTAML_DIFF_COMMAND="diff -u" dune runtest
```

- The sed-filters to clean the instrumentation output were not as portable as hoped, as they were using `\s` not supported under macOS's `sed` (both affecting CI and a local macbox)
- The cram test with its own `dune-workspace` would try to invoke `diff --color` (only relevant on a local macbox)