### PR TITLE
Add --muts option to mutaml-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ process.
    ```
    By default this prints `diff`s for each mutation that flew under
    the radar of your test suite. The `diff` output can be suppressed by
-   passing `-no-diff`.
+   passing `--no-diff`.
 
 
 Steps 3 and 4 output a number of additional files.

--- a/README.md
+++ b/README.md
@@ -139,16 +139,10 @@ If you do both, the values passed as instrumentation options in the
 `dune` file takes precedence.
 
 
-Runner and Report Options and Environment Variables
----------------------------------------------------
+Runner Options and Environment Variables
+----------------------------------------
 
-`mutaml-runner` by default repeats test suite runs for all
-instrumented `lib.ml` files. An option `--muts muts-file` is available
-to enable more targeted mutation testing.  Running `mutaml-runner
---muts lib/lib2.muts _build/default/test/mytests.exe` will for example
-only consider mutations of the corresponding library `lib/lib2.ml`.
-
-By default, `mutaml-runner` also expects to find the preprocessor's output
+By default, `mutaml-runner` expects to find the preprocessor's output
 files in the default build context `_build/default`. This can be
 configured via an environment variable or a command-line option, e.g.,
 if [instrumentation is enabled via another `dune-workspace` build context](https://dune.readthedocs.io/en/stable/instrumentation.html#enabling-disabling-instrumentation):
@@ -156,6 +150,18 @@ if [instrumentation is enabled via another `dune-workspace` build context](https
 - `MUTAML_BUILD_CONTEXT` - a path prefix string (overridden by
   command-line option `--build-context`)
 
+`mutaml-runner` also repeats test suite runs for all instrumented
+`lib.ml` files by default. An option `--muts muts-file` is available
+to enable more targeted mutation testing. Running, e.g.,
+```
+mutaml-runner --muts lib/lib2.muts _build/default/test/mytests.exe
+```
+will only consider mutations of the corresponding library
+`lib/lib2.ml`, which the runner searches for in the build context.
+
+
+Report Options and Environment Variables
+----------------------------------------
 
 Currently `mutaml-report` uses `diff --color -u` as its default
 command to print `diff`s. It falls back to `diff -u` when the

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ configured via an environment variable or a command-line option, e.g.,
 if [instrumentation is enabled via another `dune-workspace` build context](https://dune.readthedocs.io/en/stable/instrumentation.html#enabling-disabling-instrumentation):
 
 - `MUTAML_BUILD_CONTEXT` - a path prefix string (overridden by
-  command-line option `-build-context`)
+  command-line option `--build-context`)
 
 
 Currently `mutaml-report` uses `diff --color -u` as its default

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ configured an environment variable:
   and add 5 lines of unified context. Mutaml expects the specified
   command to support `--label` options.
 
+Passing the option `--no-diff` to `mutaml-report` prevents any
+mutation `diff`s from being printed.
+
 
 
 Status

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ These are all written to a dedicated directory named `_mutations`.
 
 
 
-Environment Variables and Instrumentation Options
+Instrumentation Options and Environment Variables
 -------------------------------------------------
 
 The preprocessor's behaviour can be configured through either
@@ -139,8 +139,16 @@ If you do both, the values passed as instrumentation options in the
 `dune` file takes precedence.
 
 
+Runner and Report Options and Environment Variables
+---------------------------------------------------
 
-By default, `mutaml-runner` expects to find the preprocessor's output
+`mutaml-runner` by default repeats test suite runs for all
+instrumented `lib.ml` files. An option `--muts muts-file` is available
+to enable more targeted mutation testing.  Running `mutaml-runner
+--muts lib/lib2.muts _build/default/test/mytests.exe` will for example
+only consider mutations of the corresponding library `lib/lib2.ml`.
+
+By default, `mutaml-runner` also expects to find the preprocessor's output
 files in the default build context `_build/default`. This can be
 configured via an environment variable or a command-line option, e.g.,
 if [instrumentation is enabled via another `dune-workspace` build context](https://dune.readthedocs.io/en/stable/instrumentation.html#enabling-disabling-instrumentation):

--- a/src/report/report.ml
+++ b/src/report/report.ml
@@ -54,7 +54,7 @@ struct
   let print_diff = ref true
 
   let arg_spec =
-    Arg.align ["-no-diff", Arg.Clear print_diff, " Don't output diffs to the console"]
+    Arg.align ["--no-diff", Arg.Clear print_diff, " Don't output diffs to the console"]
 
   let diff_cmd = match Sys.getenv_opt "MUTAML_DIFF_COMMAND", Sys.getenv_opt "CI" with
     | Some cmd, _       -> cmd

--- a/src/runner/runner.ml
+++ b/src/runner/runner.ml
@@ -31,8 +31,9 @@ struct
   let muts_file = ref ""
   let build_ctx = ref ""
   let arg_spec =
-    [("-muts",          Arg.Set_string muts_file, " Run mutations in the given muts-file");
-     ("-build-context", Arg.Set_string build_ctx, "Specify the build context to read from")]
+    Arg.align
+      [("--muts",          Arg.Set_string muts_file, " Run mutations in the given muts-file");
+       ("--build-context", Arg.Set_string build_ctx, " Specify the build context to read from")]
 end
 
 let ensure_output_dir dir_name =

--- a/test/negative-tests/runner-negtests.t
+++ b/test/negative-tests/runner-negtests.t
@@ -16,6 +16,11 @@ and try again:
   No files were listed in mutaml-mut-files.txt
   [1]
 
+Try passing a non-existing muts-file:
+  $ mutaml-runner --muts somefile.muts scooby-doo.sh
+  Could not read file somefile.muts - _build/default/somefile.muts: No such file or directory
+  [1]
+
 Create a mutation file with a non-existing entry:
   $ cat > _build/default/mutaml-mut-files.txt <<'EOF'
   > somefile.muts

--- a/test/negative-tests/runner-negtests.t
+++ b/test/negative-tests/runner-negtests.t
@@ -71,6 +71,6 @@ Run with an unknown build context passed as environment variable:
 
 
 Run with an unknown build context passed as command line option:
-  $ mutaml-runner -build-context _build/foofoo true
+  $ mutaml-runner --build-context _build/foofoo true
   Could not read file mutaml-mut-files.txt - _build/foofoo/mutaml-mut-files.txt: No such file or directory
   [1]

--- a/test/testproj-1-module.t/run.t
+++ b/test/testproj-1-module.t/run.t
@@ -577,7 +577,7 @@ Similar, but by passing a command line option:
   _build/mutation/ounittest.ml
 
   $ unset MUTAML_BUILD_CONTEXT
-  $ mutaml-runner -build-context "_build/mutation" _build/mutation/ounittest.exe
+  $ mutaml-runner --build-context "_build/mutation" _build/mutation/ounittest.exe
   read mut file lib.muts
   Testing mutant lib:0 ... failed
   Testing mutant lib:1 ... failed
@@ -653,7 +653,7 @@ Similar, but by passing a command line option:
   _build/mutation/ounittest.ml
 
   $ export MUTAML_BUILD_CONTEXT="_build/in-a-galaxy-far-far-away"
-  $ mutaml-runner -build-context "_build/mutation" _build/mutation/ounittest.exe
+  $ mutaml-runner --build-context "_build/mutation" _build/mutation/ounittest.exe
   read mut file lib.muts
   Testing mutant lib:0 ... failed
   Testing mutant lib:1 ... failed

--- a/test/testproj-1-module.t/run.t
+++ b/test/testproj-1-module.t/run.t
@@ -297,9 +297,9 @@ Try without providing an explicit file name:
   
 
 
-Now try the -no-diff option while providing an explicit file name:
+Now try the --no-diff option while providing an explicit file name:
 
-  $ mutaml-report -no-diff mutaml-report.json
+  $ mutaml-report --no-diff mutaml-report.json
   Attempting to read from mutaml-report.json...
   
   Mutaml report summary:
@@ -320,9 +320,9 @@ Now try the -no-diff option while providing an explicit file name:
 --------------------------------------------------------------------------------
 
 
-And try the -no-diff option without providing an explicit file name:
+And try the --no-diff option without providing an explicit file name:
 
-  $ mutaml-report -no-diff
+  $ mutaml-report --no-diff
   Attempting to read from mutaml-report.json...
   
   Mutaml report summary:
@@ -388,9 +388,9 @@ And try with a different MUTAML_DIFF_COMMAND environment variable:
   
 
 
-Also check that MUTAML_DIFF_COMMAND doesn't affect -no-diff:
+Also check that MUTAML_DIFF_COMMAND doesn't affect --no-diff:
 
-  $ mutaml-report -no-diff
+  $ mutaml-report --no-diff
   Attempting to read from mutaml-report.json...
   
   Mutaml report summary:
@@ -415,10 +415,10 @@ Now clean-up MUTAML_DIFF_COMMAND again to default again
 --------------------------------------------------------------------------------
 
 
-Now move file to a different name and retry the -no-diff option with the new name:
+Now move file to a different name and retry the --no-diff option with the new name:
 
   $ mv mutaml-report.json some-report-name.json
-  $ mutaml-report -no-diff some-report-name.json
+  $ mutaml-report --no-diff some-report-name.json
   Attempting to read from some-report-name.json...
   
   Mutaml report summary:

--- a/test/testproj-2-modules.t/run.t
+++ b/test/testproj-2-modules.t/run.t
@@ -101,3 +101,55 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   
   ---------------------------------------------------------------------------
   
+Now try testing only the mutations in src/lib1.muts:
+
+  $ mutaml-runner --muts src/lib1.muts _build/default/test/ounittest.exe
+  Testing mutant src/lib1:0 ... failed
+  Testing mutant src/lib1:1 ... failed
+  Testing mutant src/lib1:2 ... failed
+  Writing report data to mutaml-report.json
+
+And report a summary:
+
+  $ mutaml-report
+  Attempting to read from mutaml-report.json...
+  
+  Mutaml report summary:
+  ----------------------
+  
+   target                          #mutations      #failed      #timeouts      #passed 
+   -------------------------------------------------------------------------------------
+   src/lib1.ml                            3     100.0%    3     0.0%    0     0.0%    0
+   =====================================================================================
+  
+
+Now try the same for src/lib2.muts:
+
+  $ mutaml-runner --muts src/lib2.muts _build/default/test/ounittest.exe
+  Testing mutant src/lib2:0 ... passed
+  Testing mutant src/lib2:1 ... passed
+  Testing mutant src/lib2:2 ... passed
+  Testing mutant src/lib2:3 ... failed
+  Testing mutant src/lib2:4 ... failed
+  Testing mutant src/lib2:5 ... failed
+  Writing report data to mutaml-report.json
+
+And report a diff-free summary:
+
+  $ mutaml-report --no-diff
+  Attempting to read from mutaml-report.json...
+  
+  Mutaml report summary:
+  ----------------------
+  
+   target                          #mutations      #failed      #timeouts      #passed 
+   -------------------------------------------------------------------------------------
+   src/lib2.ml                            6      50.0%    3     0.0%    0    50.0%    3
+   =====================================================================================
+  
+  Mutation programs passing the test suite:
+  -----------------------------------------
+  
+  Mutation "src/lib2.ml-mutant0" passed (see "_mutations/src/lib2.ml-mutant0.output")
+  Mutation "src/lib2.ml-mutant1" passed (see "_mutations/src/lib2.ml-mutant1.output")
+  Mutation "src/lib2.ml-mutant2" passed (see "_mutations/src/lib2.ml-mutant2.output")


### PR DESCRIPTION
This PR addresses #5 by adding an option `--muts` to `mutaml-runner`.
In this first version, only a single specified `.muts`-file is supported.
While writing the README, I however started wondering whether specifying an `.ml`-file would perhaps be more user-friendly, rather than exposing an implementation detail such as `.muts` files?  :thinking: 

For uniformity, the PR also changes the existing `mutaml-runner` and `mutaml-report` options to all use a two dash `--` prefix, which seems to be the CLI standard for non-single-char options.
I've however kept single-dash options in the ppxlib instrumentation to be consistent with the other available `dune` instrumentation flags.

Ping @raphael-proust 