### PR TITLE
Filter ld warnings causing CI errors on x86_32

### DIFF
--- a/test/filter_dune_build.sh
+++ b/test/filter_dune_build.sh
@@ -4,6 +4,7 @@
 #   filter [@@@ocaml.ppx.context whitespace {  0-or-more not-close-brace-chars }]
 #   and normalize file system paths
 dune build $@ 2>&1 | \
-    sed  -E 'H;1h;$!d;x;s/\[@@@ocaml\.ppx\.context\n\ \ \{[^}]*\}\]//g' | \
+    sed -E 'H;1h;$!d;x;s/\[@@@ocaml\.ppx\.context\n\ \ \{[^}]*\}\]//g' | \
+    sed -E "/^\/usr\/bin\/ld/d" | \
     sed 's/home[^ ]*bin\//some\/path\/...\/bin\//' | \
     sed 's/Users[^ ]*bin\//some\/path\/...\/bin\//'

--- a/test/instrumentation-tests/ppx-args.t
+++ b/test/instrumentation-tests/ppx-args.t
@@ -22,7 +22,7 @@ Test default behaviour when passing only seed as environment variable
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -34,7 +34,7 @@ Try passing another seed value:
   $ dune clean
   $ export MUTAML_SEED=4231
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 4231   Mutation rate: 50   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -66,7 +66,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -88,7 +88,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -111,7 +111,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: false
   Created 1 mutation of test.ml
@@ -128,7 +128,7 @@ Force dune to rebuild
 
   $ export MUTAML_GADT=false
 
-  $ dune build ./test.bc --force --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --force --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: false
   Created 1 mutation of test.ml
@@ -161,7 +161,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 42   Mutation rate: 50   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -177,7 +177,7 @@ Force dune to rebuild
 
   $ export MUTAML_SEED=896745231
 
-  $ dune build ./test.bc --force --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --force --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 42   Mutation rate: 50   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -208,7 +208,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -218,7 +218,7 @@ Try with another value - 33:
 
   $ dune clean
   $ export MUTAML_MUT_RATE=33
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 33   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -228,7 +228,7 @@ Try with another value - 0:
 
   $ dune clean
   $ export MUTAML_MUT_RATE=0
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 0   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -250,7 +250,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 75   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -265,7 +265,7 @@ Here the dune file parameter should take precedence
 
   $ export MUTAML_MUT_RATE=100
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 75   GADTs enabled: true
   Created 1 mutation of test.ml
@@ -286,7 +286,7 @@ Instrument and check that they were received
   > EOF
 
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 42   Mutation rate: 75   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -323,7 +323,7 @@ Instrument and check that it was received - with no mutation
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 0   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -334,7 +334,7 @@ Repeat with a few other seeds:
 
   $ dune clean
   $ export MUTAML_SEED=325
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 325   Mutation rate: 0   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -343,7 +343,7 @@ Repeat with a few other seeds:
 
   $ dune clean
   $ export MUTAML_SEED=87324
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 87324   Mutation rate: 0   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -352,7 +352,7 @@ Repeat with a few other seeds:
 
   $ dune clean
   $ export MUTAML_SEED=9825453
-  $ dune build ./test.bc --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 9825453   Mutation rate: 0   GADTs enabled: true
   Created 0 mutations of test.ml
@@ -382,7 +382,7 @@ And a dune file:
 
   $ dune clean
   $ export MUTAML_SEED=896745231
-  $ dune build _build/mutation/test.bc --force
+  $ bash ../filter_dune_build.sh _build/mutation/test.bc --force
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 7 mutations of test.ml

--- a/test/negative-tests/ppx-negtests.t
+++ b/test/negative-tests/ppx-negtests.t
@@ -20,7 +20,7 @@ Test invalid environment variables
   > EOF
 
   $ export MUTAML_GADT=sometimes
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ Test invalid environment variables
   $ dune clean
   $ unset MUTAML_GADT
   $ export MUTAML_SEED=-4611686018427387905
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ Test invalid environment variables
 
   $ dune clean
   $ export MUTAML_SEED=4611686018427387904
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ Test invalid environment variables
 
   $ dune clean
   $ export MUTAML_SEED=12likeREEEAALLLYrandom34
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,7 @@ Test invalid environment variables
   $ dune clean
   $ unset MUTAML_SEED
   $ export MUTAML_MUT_RATE=110
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ Test invalid environment variables
 
   $ dune clean
   $ export MUTAML_MUT_RATE=-10
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ Test invalid environment variables
 
   $ dune clean
   $ export MUTAML_MUT_RATE=always
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-35:
   4 |  (instrumentation (backend mutaml))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ Instrument and check that it is rejected
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-49:
   4 |  (instrumentation (backend mutaml -mut-rate 110))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ Instrument and check that it is rejected
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-49:
   4 |  (instrumentation (backend mutaml -mut-rate -10))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -150,7 +150,7 @@ Instrument and check that it is rejected
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-66:
   4 |  (instrumentation (backend mutaml -mut-rate eeeEEEEEXTREMELYHIGH))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ Instrument and check that it is rejected
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-61:
   4 |  (instrumentation (backend mutaml -seed 4611686018427387904))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,7 +202,7 @@ Instrument and check that it is rejected
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | head | sed -e 's/ppx\/[^\/]*\/ppx\.exe/ppx\/path\/ppx\.exe/g'
   File "dune", line 4, characters 1-54:
   4 |  (instrumentation (backend mutaml -seed 324random345))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -228,7 +228,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ dune build ./test.bc --instrument-with mutaml 2>&1 | grep -v "no-merge"
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | grep -v "no-merge"
   ppx.exe [extra_args] [<files>]
     -as-ppx                     Run as a -ppx rewriter (must be the first argument)
     --as-ppx                    Same as -as-ppx

--- a/test/testproj-1-module.t/run.t
+++ b/test/testproj-1-module.t/run.t
@@ -45,7 +45,7 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   $ export MUTAML_SEED=896745231
   $ export MUTAML_MUT_RATE=100
 
-  $ dune build ./ounittest.exe --instrument-with mutaml
+  $ bash ../filter_dune_build.sh ./ounittest.exe --instrument-with mutaml
   Running mutaml instrumentation on "lib.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 13 mutations of lib.ml
@@ -454,7 +454,7 @@ Create a dune-workspace file with another build context:
   $ dune clean
   $ unset MUTAML_MUT_RATE
   $ export MUTAML_SEED=896745231
-  $ dune build ./ounittest.exe
+  $ bash ../filter_dune_build.sh ./ounittest.exe
   Running mutaml instrumentation on "lib.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 9 mutations of lib.ml
@@ -564,7 +564,7 @@ Create a dune-workspace file with another build context:
 Similar, but by passing a command line option:
 
   $ dune clean
-  $ dune build ./ounittest.exe
+  $ bash ../filter_dune_build.sh ./ounittest.exe
   Running mutaml instrumentation on "lib.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 9 mutations of lib.ml
@@ -640,7 +640,7 @@ Finally, test overriding:
 Similar, but by passing a command line option:
 
   $ dune clean
-  $ dune build ./ounittest.exe
+  $ bash ../filter_dune_build.sh ./ounittest.exe
   Running mutaml instrumentation on "lib.ml"
   Randomness seed: 896745231   Mutation rate: 50   GADTs enabled: true
   Created 9 mutations of lib.ml

--- a/test/testproj-2-modules.t/run.t
+++ b/test/testproj-2-modules.t/run.t
@@ -18,7 +18,7 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   $ export MUTAML_SEED=896745231
   $ export MUTAML_MUT_RATE=100
 
-  $ dune build test/ounittest.exe --instrument-with mutaml
+  $ bash ../filter_dune_build.sh test/ounittest.exe --instrument-with mutaml
   Running mutaml instrumentation on "src/lib1.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 3 mutations of src/lib1.ml


### PR DESCRIPTION
The CI is failing on x86_32 due to an outstanding issue in the compiler: https://github.com/ocaml/ocaml/issues/12166
This results in the following warning being emitted from `/usr/bin/ld` which again causes CI to fail cram tests due to the diff:
```
/usr/bin/ld: /src/_build/install/default/lib/mutaml/mutaml_ppx.a(rS.o): warning: relocation in read-only section `.text'
/usr/bin/ld: warning: creating DT_TEXTREL in a PIE
```

The PR
- updates the filter script to weed them out
- updates the remaining cram tests to use the filter script

With the PR we are therefore CI green on x86_32 :heavy_check_mark: :tada: 