### PR TITLE
Add lower bounds for transitive deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,4 +32,8 @@
   conf-timeout
   conf-which
   conf-diffutils
+  ;; transitive lower versions to avoid CI errors
+  (ocaml-compiler-libs (>= v0.12.0))
+  (ppx_derivers (>= 1.2.1))
+  (yojson (>= 2.0.0))
   (ounit2 :with-test)))

--- a/mutaml.opam
+++ b/mutaml.opam
@@ -24,6 +24,9 @@ depends: [
   "conf-timeout"
   "conf-which"
   "conf-diffutils"
+  "ocaml-compiler-libs" {>= "v0.12.0"}
+  "ppx_derivers" {>= "1.2.1"}
+  "yojson" {>= "2.0.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
opam's lower bounds check is effective to the point that it finds an annoying combination involving
- ocaml-compiler-libs.v0.11.0 
- ppx_derivers.1.0
- biniou.1.2.0

which are all transitive dependencies of `mutaml` that make the cram diff tests fail because of warnings such as the following:
```
+  File "/home/opam/.opam/4.12/lib/ocaml-compiler-libs/toplevel/ocaml-compiler-libs.toplevel.dune", line 1, characters 0-0:
+  Warning: .dune files are ignored since 2.0. Reinstall the library with dune
+  >= 2.0 to get rid of this warning and enable support for the subsystem this
+  library provides.
+  File "/home/opam/.opam/4.12/lib/ppx_derivers/ppx_derivers.dune", line 1, characters 0-0:
+  Warning: .dune files are ignored since 2.0. Reinstall the library with dune
+  >= 2.0 to get rid of this warning and enable support for the subsystem this
+  library provides.
+  File "/home/opam/.opam/4.12/lib/biniou/biniou.dune", line 1, characters 0-0:
+  Warning: .dune files are ignored since 2.0. Reinstall the library with dune
+  >= 2.0 to get rid of this warning and enable support for the subsystem this
+  library provides.
```

Rather than filter output further, this PR adds suitable lower bounds for transitive deps.
Incrementing yojson to min. 2.0.0 avoids a transitive `biniou` dependency.

With this PR only two red CI lights remain:
- an internal parse error in the experimental `opam-dune-lint.dev`
- 4.14 ppc64 errors because some mutations cause timeouts rather than errors (due to slowness or missing overflow protection I suspect)