### PR TITLE
Avoid mutations in attribute parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Next version
 ------------
 
-- ...
+- Avoid mutations in attribute parameters #29
 
 0.2
 ---

--- a/dune-project
+++ b/dune-project
@@ -36,4 +36,5 @@
   (ocaml-compiler-libs (>= v0.12.0))
   (ppx_derivers (>= 1.2.1))
   (yojson (>= 2.0.0))
+  (ppx_deriving :with-test)
   (ounit2 :with-test)))

--- a/mutaml.opam
+++ b/mutaml.opam
@@ -28,6 +28,7 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.12.0"}
   "ppx_derivers" {>= "1.2.1"}
   "yojson" {>= "2.0.0"}
+  "ppx_deriving" {with-test}
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/ppx/mutaml_ppx.ml
+++ b/src/ppx/mutaml_ppx.ml
@@ -488,6 +488,8 @@ class mutate_mapper (rs : RS.t) =
     | _ ->
       super#expression ctx e
 
+  (* don't mutate attribute parameters such as 'false' in [@@deriving show {with_path=false}] *)
+  method! attributes _ctx attrs = return attrs
 
   method transform_impl_file ctx impl_ast =
     let input_name = Base_exp_context.input_name ctx in

--- a/test/issue-attributes.t/run.t
+++ b/test/issue-attributes.t/run.t
@@ -1,0 +1,58 @@
+Let us try something:
+
+  $ ls ../filter_dune_build.sh
+  ../filter_dune_build.sh
+
+Create a file with a deriving show attribute https://github.com/jmid/mutaml/issues/28
+  $ cat > test.ml << EOF
+  > type some_type = A | B [@@deriving show {with_path = false}]
+  > type another_type = C | D of some_type [@@deriving show {with_path = false}]
+  > ;;
+  > assert (show_another_type C = "C")
+  > EOF
+
+Create the dune files:
+  $ cat > dune-project << EOF
+  > (lang dune 2.9)
+  > EOF
+
+  $ cat > dune <<'EOF'
+  > (executable
+  >  (name test)
+  >  (preprocess (pps ppx_deriving.show))
+  >  (instrumentation (backend mutaml))
+  > )
+  > EOF
+
+Check that files were created as expected:
+  $ ls dune* test.ml
+  dune
+  dune-project
+  test.ml
+
+Set seed and (full) mutation rate as environment variables, for repeatability
+  $ export MUTAML_SEED=896745231
+  $ export MUTAML_MUT_RATE=100
+
+  $ ../filter_dune_build.sh ./test.exe --instrument-with mutaml
+  Running mutaml instrumentation on "test.ml"
+  Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
+  Created 0 mutations of test.ml
+  Writing mutation info to test.muts
+
+  $ ls _build
+  default
+  log
+
+  $ ls _build/default
+  mutaml-mut-files.txt
+  test.exe
+  test.ml
+  test.muts
+  test.pp.ml
+
+  $ mutaml-runner _build/default/test.exe
+  read mut file test.muts
+  Warning: No mutations were listed in test.muts
+  Did not find any mutations across the files listed in mutaml-mut-files.txt
+  [1]


### PR DESCRIPTION
This fixes the first issue reported in #28.

The problem is that mutaml attempts to mutate the Boolean literal `false` in a type such as the below:
```ocaml
type some_type = A | B [@@deriving show {with_path = false}]
```
This is not compatible with the current architecture, which compiles - and hence preprocesses once, and then runs the resulting output repeatedly with different environment definitions.