### PR TITLE
Fix incompatibility with Core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Next version
 ------------
 
 - Avoid mutations in attribute parameters #29
+- Avoid polymorphic equality which is incompatible with Core #30
 
 0.2
 ---

--- a/test/instrumentation-tests/arith.t
+++ b/test/instrumentation-tests/arith.t
@@ -21,7 +21,11 @@ Test + 1:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x = if __MUTAML_MUTANT__ = (Some "test:0") then x else x + 1
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x = if __is_mutaml_mutant__ "test:0" then x else x + 1
   ;;assert ((f 5) = 6)
 
 Check that instrumentation hasn't changed the program's behaviour
@@ -48,7 +52,11 @@ Test - 1:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x = if __MUTAML_MUTANT__ = (Some "test:0") then x else x - 1
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x = if __is_mutaml_mutant__ "test:0" then x else x - 1
   ;;assert ((f 5) = 4)
 
   $ dune exec --no-build ./test.bc
@@ -73,7 +81,11 @@ z
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x = if __MUTAML_MUTANT__ = (Some "test:0") then x else 1 + x
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x = if __is_mutaml_mutant__ "test:0" then x else 1 + x
   ;;assert ((f 5) = 6)
 
   $ dune exec --no-build ./test.bc
@@ -98,7 +110,11 @@ Test addition:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x y = if __MUTAML_MUTANT__ = (Some "test:0") then x - y else x + y
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x y = if __is_mutaml_mutant__ "test:0" then x - y else x + y
   ;;assert ((f 5 6) = 11)
 
   $ dune exec --no-build ./test.bc
@@ -123,7 +139,11 @@ Test subtraction mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x y = if __MUTAML_MUTANT__ = (Some "test:0") then x + y else x - y
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x y = if __is_mutaml_mutant__ "test:0" then x + y else x - y
   ;;assert ((f 6 5) = 1)
 
   $ dune exec --no-build ./test.bc
@@ -148,7 +168,11 @@ Test multiplication mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x y = if __MUTAML_MUTANT__ = (Some "test:0") then x + y else x * y
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x y = if __is_mutaml_mutant__ "test:0" then x + y else x * y
   ;;assert ((f 6 5) = 30)
 
   $ dune exec --no-build ./test.bc
@@ -169,7 +193,11 @@ Test division mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x y = if __MUTAML_MUTANT__ = (Some "test:0") then x mod y else x / y
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x y = if __is_mutaml_mutant__ "test:0" then x mod y else x / y
   ;;assert ((f 56 5) = 11)
 
   $ dune exec --no-build ./test.bc
@@ -194,7 +222,11 @@ Test modulo mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f x y = if __MUTAML_MUTANT__ = (Some "test:0") then x / y else x mod y
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f x y = if __is_mutaml_mutant__ "test:0" then x / y else x mod y
   ;;assert ((f 56 6) = 2)
 
   $ dune exec --no-build ./test.bc
@@ -239,10 +271,14 @@ we should use it instead.
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let f x y =
     let __MUTAML_TMP0__ = let () = print_endline "right" in y in
     let __MUTAML_TMP1__ = let () = print_endline "left" in x in
-    if __MUTAML_MUTANT__ = (Some "test:0")
+    if __is_mutaml_mutant__ "test:0"
     then __MUTAML_TMP1__ - __MUTAML_TMP0__
     else __MUTAML_TMP1__ + __MUTAML_TMP0__
   ;;assert ((f 5 6) = 11)

--- a/test/instrumentation-tests/assert.t
+++ b/test/instrumentation-tests/assert.t
@@ -57,9 +57,13 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let foo =
     match Sys.word_size with
-    | 32 -> if __MUTAML_MUTANT__ = (Some "test:0") then 33 else 32
+    | 32 -> if __is_mutaml_mutant__ "test:0" then 33 else 32
     | _ -> assert false
 
 
@@ -81,12 +85,16 @@ Make an .ml-file:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let foo =
     match Sys.word_size with
-    | 32 -> if __MUTAML_MUTANT__ = (Some "test:0") then 33 else 32
+    | 32 -> if __is_mutaml_mutant__ "test:0" then 33 else 32
     | _ ->
-        (if __MUTAML_MUTANT__ = (Some "test:2") then () else assert (1 > 0);
-         if __MUTAML_MUTANT__ = (Some "test:1") then 1 else 0)
+        (if __is_mutaml_mutant__ "test:2" then () else assert (1 > 0);
+         if __is_mutaml_mutant__ "test:1" then 1 else 0)
 
 
   $ MUTAML_MUTANT="test:0" dune exec --no-build -- ./test.bc
@@ -116,17 +124,20 @@ Make an .ml-file:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let () =
     let tmp =
-      (if __MUTAML_MUTANT__ = (Some "test:0") then false else true) =
-        (not (if __MUTAML_MUTANT__ = (Some "test:1") then true else false)) in
+      (if __is_mutaml_mutant__ "test:0" then false else true) =
+        (not (if __is_mutaml_mutant__ "test:1" then true else false)) in
     assert tmp
   let () =
     let tmp =
-      (String.length (if __MUTAML_MUTANT__ = (Some "test:2") then "" else " "))
-        =
+      (String.length (if __is_mutaml_mutant__ "test:2" then "" else " ")) =
         (let __MUTAML_TMP0__ = String.length "" in
-         if __MUTAML_MUTANT__ = (Some "test:3")
+         if __is_mutaml_mutant__ "test:3"
          then __MUTAML_TMP0__
          else 1 + __MUTAML_TMP0__) in
     assert tmp

--- a/test/instrumentation-tests/attributes.t
+++ b/test/instrumentation-tests/attributes.t
@@ -35,14 +35,17 @@ Set seed and (full) mutation rate as environment variables, for repeatability
 
 Preprocess, check for attribute and error
   $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 > output.txt
-  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 9 output.txt
+  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 12 output.txt
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 0 mutations of test.ml
   Writing mutation info to test.muts
   ERROR MESSAGE
-  
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let greet () = print_endline ("Hello," ^ " world!")[@@ppwarning
                                                        "Stop using hello world!"]
   let () = greet ()
@@ -70,6 +73,10 @@ Preprocess, check that attribute no longer triggers an error
   $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let greet () = print_endline ("Hello," ^ " world!")[@@ppwarning
                                                        "Stop using hello world!"]
   let () = greet ()
@@ -102,13 +109,17 @@ Create a test.ml file with a module attribute
 Preprocess, check that attribute triggers deprecation error
 
   $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 > output.txt
-  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 10 output.txt
+  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 14 output.txt
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 0 mutations of test.ml
   Writing mutation info to test.muts
   ERROR MESSAGE
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   module T :
     sig val greet : unit -> unit[@@deprecated "Please stop using that example"]
     end = struct let greet () = print_endline ("Hello," ^ " world!") end 
@@ -149,6 +160,10 @@ Preprocess, check for attribute and error
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let v = ((())[@testattr "unit attr"])
 
 
@@ -169,12 +184,16 @@ Preprocess, check for attribute and error
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let t =
-    if __MUTAML_MUTANT__ = (Some "test:0")
+    if __is_mutaml_mutant__ "test:0"
     then ((false)[@testattr "true attr"])
     else ((true)[@testattr "true attr"])
   let f =
-    if __MUTAML_MUTANT__ = (Some "test:1")
+    if __is_mutaml_mutant__ "test:1"
     then ((true)[@testattr "false attr"])
     else ((false)[@testattr "false attr"])
 
@@ -195,8 +214,12 @@ Preprocess, check for attribute and error
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let str =
-    if __MUTAML_MUTANT__ = (Some "test:0")
+    if __is_mutaml_mutant__ "test:0"
     then (("")[@testattr "str attr"])
     else ((" ")[@testattr "str attr"])
 
@@ -217,8 +240,12 @@ Preprocess, check for attribute and error
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let f x =
-    if __MUTAML_MUTANT__ = (Some "test:0")
+    if __is_mutaml_mutant__ "test:0"
     then ((x)[@testattr "str attr"])
     else ((x + 1)[@testattr "str attr"])
 

--- a/test/instrumentation-tests/bool.t
+++ b/test/instrumentation-tests/bool.t
@@ -21,7 +21,11 @@ Test true:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f () = if __MUTAML_MUTANT__ = (Some "test:0") then false else true
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f () = if __is_mutaml_mutant__ "test:0" then false else true
   ;;assert (f ())
 
 
@@ -49,7 +53,11 @@ Test false:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let f () = if __MUTAML_MUTANT__ = (Some "test:0") then true else false
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let f () = if __is_mutaml_mutant__ "test:0" then true else false
   ;;assert (not (f ()))
 
   $ dune exec --no-build ./test.bc

--- a/test/instrumentation-tests/function-merge-consecutive.t
+++ b/test/instrumentation-tests/function-merge-consecutive.t
@@ -29,6 +29,10 @@ An example with only conservative, GADT-safe mutations:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type t =
     | A 
     | B 
@@ -61,14 +65,18 @@ Same example but allowing GADT-unsafe mutations:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type t =
     | A 
     | B 
     | C 
   let f =
     ((function
-      | A when __MUTAML_MUTANT__ <> (Some "test:1") -> "A"
-      | A | B when __MUTAML_MUTANT__ <> (Some "test:0") -> "B"
+      | A when not (__is_mutaml_mutant__ "test:1") -> "A"
+      | A | B when not (__is_mutaml_mutant__ "test:0") -> "B"
       | B | C -> "C")
     [@ocaml.warning "-8"])
   let () = (f A) |> print_endline
@@ -187,12 +195,16 @@ Instead we trigger the collapse-consecutive-patterns mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let rec count_zeroes =
     ((function
-      | [] -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-      | 0::xs when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | [] -> if __is_mutaml_mutant__ "test:0" then 1 else 0
+      | 0::xs when not (__is_mutaml_mutant__ "test:2") ->
           let __MUTAML_TMP0__ = count_zeroes xs in
-          if __MUTAML_MUTANT__ = (Some "test:1")
+          if __is_mutaml_mutant__ "test:1"
           then __MUTAML_TMP0__
           else 1 + __MUTAML_TMP0__
       | 0::xs | _::xs -> count_zeroes xs)
@@ -200,22 +212,22 @@ Instead we trigger the collapse-consecutive-patterns mutation:
   let () = (count_zeroes []) |> (Printf.printf "%i\n")
   let () =
     (count_zeroes
-       [if __MUTAML_MUTANT__ = (Some "test:3") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:4") then 1 else 0])
+       [if __is_mutaml_mutant__ "test:3" then 0 else 1;
+       if __is_mutaml_mutant__ "test:4" then 1 else 0])
       |> (Printf.printf "%i\n")
   let () =
     (count_zeroes
-       [if __MUTAML_MUTANT__ = (Some "test:5") then 1 else 0;
-       if __MUTAML_MUTANT__ = (Some "test:6") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:7") then 1 else 0])
+       [if __is_mutaml_mutant__ "test:5" then 1 else 0;
+       if __is_mutaml_mutant__ "test:6" then 0 else 1;
+       if __is_mutaml_mutant__ "test:7" then 1 else 0])
       |> (Printf.printf "%i\n")
   let () =
     (count_zeroes
-       [if __MUTAML_MUTANT__ = (Some "test:8") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:9") then 1 else 0;
-       if __MUTAML_MUTANT__ = (Some "test:10") then 1 else 0;
-       if __MUTAML_MUTANT__ = (Some "test:11") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:12") then 1 else 0])
+       [if __is_mutaml_mutant__ "test:8" then 0 else 1;
+       if __is_mutaml_mutant__ "test:9" then 1 else 0;
+       if __is_mutaml_mutant__ "test:10" then 1 else 0;
+       if __is_mutaml_mutant__ "test:11" then 0 else 1;
+       if __is_mutaml_mutant__ "test:12" then 1 else 0])
       |> (Printf.printf "%i\n")
 
 
@@ -484,6 +496,10 @@ Another example would triggers merge-of-consecutive-patterns w/GADTs true
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type binop =
     | Add 
     | Mul 
@@ -498,18 +514,17 @@ Another example would triggers merge-of-consecutive-patterns w/GADTs true
     | Binop (ae0, Add, ae1) ->
         let v0 = interpret xval ae0 in
         let v1 = interpret xval ae1 in
-        if __MUTAML_MUTANT__ = (Some "test:0") then v0 - v1 else v0 + v1
+        if __is_mutaml_mutant__ "test:0" then v0 - v1 else v0 + v1
     | Binop (ae0, Mul, ae1) ->
         let v0 = interpret xval ae0 in
         let v1 = interpret xval ae1 in
-        if __MUTAML_MUTANT__ = (Some "test:1") then v0 + v1 else v0 * v1
+        if __is_mutaml_mutant__ "test:1" then v0 + v1 else v0 * v1
   let () =
-    (interpret (if __MUTAML_MUTANT__ = (Some "test:2") then 3 else 2)
+    (interpret (if __is_mutaml_mutant__ "test:2" then 3 else 2)
        (Binop
-          ((Lit (if __MUTAML_MUTANT__ = (Some "test:3") then 0 else 1)), Add,
+          ((Lit (if __is_mutaml_mutant__ "test:3" then 0 else 1)), Add,
             (Binop
-               (X, Mul,
-                 (Lit (if __MUTAML_MUTANT__ = (Some "test:4") then 4 else 3)))))))
+               (X, Mul, (Lit (if __is_mutaml_mutant__ "test:4" then 4 else 3)))))))
       |> (Printf.printf "1 + x*3 = %i\n")
 
 
@@ -632,6 +647,10 @@ Same example that triggers merge-of-consecutive-patterns w/GADTs false
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type binop =
     | Add 
     | Mul 
@@ -643,22 +662,21 @@ Same example that triggers merge-of-consecutive-patterns w/GADTs false
     ((function
       | X -> xval
       | Lit i -> i
-      | Binop (ae0, Add, ae1) when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | Binop (ae0, Add, ae1) when not (__is_mutaml_mutant__ "test:2") ->
           let v0 = interpret xval ae0 in
           let v1 = interpret xval ae1 in
-          if __MUTAML_MUTANT__ = (Some "test:0") then v0 - v1 else v0 + v1
+          if __is_mutaml_mutant__ "test:0" then v0 - v1 else v0 + v1
       | Binop (ae0, Add, ae1) | Binop (ae0, Mul, ae1) ->
           let v0 = interpret xval ae0 in
           let v1 = interpret xval ae1 in
-          if __MUTAML_MUTANT__ = (Some "test:1") then v0 + v1 else v0 * v1)
+          if __is_mutaml_mutant__ "test:1" then v0 + v1 else v0 * v1)
     [@ocaml.warning "-8"])
   let () =
-    (interpret (if __MUTAML_MUTANT__ = (Some "test:3") then 3 else 2)
+    (interpret (if __is_mutaml_mutant__ "test:3" then 3 else 2)
        (Binop
-          ((Lit (if __MUTAML_MUTANT__ = (Some "test:4") then 0 else 1)), Add,
+          ((Lit (if __is_mutaml_mutant__ "test:4" then 0 else 1)), Add,
             (Binop
-               (X, Mul,
-                 (Lit (if __MUTAML_MUTANT__ = (Some "test:5") then 4 else 3)))))))
+               (X, Mul, (Lit (if __is_mutaml_mutant__ "test:5" then 4 else 3)))))))
       |> (Printf.printf "1 + x*3 = %i\n")
 
 

--- a/test/instrumentation-tests/function-omit-case.t
+++ b/test/instrumentation-tests/function-omit-case.t
@@ -26,13 +26,17 @@ Make an .ml-file:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let identify_char =
     ((function
-      | 'a'..'z' when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | 'a'..'z' when not (__is_mutaml_mutant__ "test:2") ->
           "lower-case letter"
-      | 'A'..'Z' when __MUTAML_MUTANT__ <> (Some "test:1") ->
+      | 'A'..'Z' when not (__is_mutaml_mutant__ "test:1") ->
           "upper-case letter"
-      | '0'..'9' when __MUTAML_MUTANT__ <> (Some "test:0") -> "digit"
+      | '0'..'9' when not (__is_mutaml_mutant__ "test:0") -> "digit"
       | _ -> "other")
     [@ocaml.warning "-8"])
   let () = print_endline (identify_char 'e')
@@ -157,17 +161,20 @@ Test that same example with a variable will be instrumented with this mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let identify_char =
     ((function
-      | 'a'..'z' when __MUTAML_MUTANT__ <> (Some "test:3") ->
+      | 'a'..'z' when not (__is_mutaml_mutant__ "test:3") ->
           "lower-case letter"
-      | 'A'..'Z' when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | 'A'..'Z' when not (__is_mutaml_mutant__ "test:2") ->
           "upper-case letter"
-      | '0'..'9' when __MUTAML_MUTANT__ <> (Some "test:1") -> "digit"
+      | '0'..'9' when not (__is_mutaml_mutant__ "test:1") -> "digit"
       | c ->
           "other char: " ^
-            (String.make (if __MUTAML_MUTANT__ = (Some "test:0") then 0 else 1)
-               c))
+            (String.make (if __is_mutaml_mutant__ "test:0" then 0 else 1) c))
     [@ocaml.warning "-8"])
   let () = print_endline (identify_char 'e')
   let () = print_endline (identify_char 'U')
@@ -311,10 +318,14 @@ Another test w/tuples and wildcards:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let prioritize fallback =
     function
-    | (Some x, _) when __MUTAML_MUTANT__ <> (Some "test:1") -> x
-    | (_, Some y) when __MUTAML_MUTANT__ <> (Some "test:0") -> y
+    | (Some x, _) when not (__is_mutaml_mutant__ "test:1") -> x
+    | (_, Some y) when not (__is_mutaml_mutant__ "test:0") -> y
     | (_, _) -> fallback
   ;;(prioritize "3rd" ((Some "1st"), (Some "2nd"))) |> print_endline
   ;;(prioritize "3rd" ((Some "1st"), None)) |> print_endline
@@ -414,6 +425,10 @@ Same example without wildcards will not be instrumented with this mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let prioritize fallback =
     function | (Some x, _) -> x | (_, Some y) -> y | (None, None) -> fallback
   ;;(prioritize "3rd" ((Some "1st"), (Some "2nd"))) |> print_endline

--- a/test/instrumentation-tests/gadts.t
+++ b/test/instrumentation-tests/gadts.t
@@ -31,13 +31,17 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
   let f (type a) =
     (function
-     | Int -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-     | Bool -> if __MUTAML_MUTANT__ = (Some "test:1") then false else true : 
+     | Int -> if __is_mutaml_mutant__ "test:0" then 1 else 0
+     | Bool -> if __is_mutaml_mutant__ "test:1" then false else true : 
     a t -> a)
   let () = (f Int) |> (Printf.printf "%i\n")
 
@@ -72,14 +76,18 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
   let f (type a) =
     (fun x ->
        match x with
-       | Int -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-       | Bool -> if __MUTAML_MUTANT__ = (Some "test:1") then false else true : 
+       | Int -> if __is_mutaml_mutant__ "test:0" then 1 else 0
+       | Bool -> if __is_mutaml_mutant__ "test:1" then false else true : 
     a t -> a)
   let () = (f Int) |> (Printf.printf "%i\n")
 
@@ -112,6 +120,10 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
@@ -148,6 +160,10 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
@@ -184,6 +200,10 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
@@ -224,15 +244,19 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
   let f (type a) =
     (function
-     | [|Int;Int|] when __MUTAML_MUTANT__ <> (Some "test:3") ->
-         if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-     | [|Bool|] when __MUTAML_MUTANT__ <> (Some "test:2") ->
-         if __MUTAML_MUTANT__ = (Some "test:1") then false else true
+     | [|Int;Int|] when not (__is_mutaml_mutant__ "test:3") ->
+         if __is_mutaml_mutant__ "test:0" then 1 else 0
+     | [|Bool|] when not (__is_mutaml_mutant__ "test:2") ->
+         if __is_mutaml_mutant__ "test:1" then false else true
      | _ -> failwith "ouch" : a t array -> a)
 
 
@@ -269,25 +293,29 @@ Check that the example typechecks
   $ export MUTAML_SEED=896745231
   $ export MUTAML_GADT=true
   $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 > output.txt
-  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 25 output.txt
+  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 29 output.txt
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 4 mutations of test.ml
   Writing mutation info to test.muts
   ERROR MESSAGE
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
     | Char: char t 
   let f (type a) =
     (function
-     | [|Int|] -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-     | [|Bool|] -> if __MUTAML_MUTANT__ = (Some "test:1") then false else true
+     | [|Int|] -> if __is_mutaml_mutant__ "test:0" then 1 else 0
+     | [|Bool|] -> if __is_mutaml_mutant__ "test:1" then false else true
      | [|Char|] -> 'c'
-     | _ when if __MUTAML_MUTANT__ = (Some "test:2") then false else true ->
+     | _ when if __is_mutaml_mutant__ "test:2" then false else true ->
          failwith "empty"
-     | _ when if __MUTAML_MUTANT__ = (Some "test:3") then true else false ->
+     | _ when if __is_mutaml_mutant__ "test:3" then true else false ->
          failwith "dead" : a t array -> a)
   File "test.ml", lines 6-11, characters 34-34:
    6 | ..................................function
@@ -327,15 +355,19 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
   let f (type a) =
     (function
-     | [|_x;Int|] when __MUTAML_MUTANT__ <> (Some "test:3") ->
-         if __MUTAML_MUTANT__ = (Some "test:0") then 3 else 2
-     | [|Bool;_x|] when __MUTAML_MUTANT__ <> (Some "test:2") ->
-         if __MUTAML_MUTANT__ = (Some "test:1") then false else true
+     | [|_x;Int|] when not (__is_mutaml_mutant__ "test:3") ->
+         if __is_mutaml_mutant__ "test:0" then 3 else 2
+     | [|Bool;_x|] when not (__is_mutaml_mutant__ "test:2") ->
+         if __is_mutaml_mutant__ "test:1" then false else true
      | _ -> failwith "eww" : a t array -> a)
 
 
@@ -364,27 +396,27 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
   let _f (type a) (type b) =
     (function
-     | (Int, _) when __MUTAML_MUTANT__ <> (Some "test:4") ->
-         if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-     | (_, Bool) when __MUTAML_MUTANT__ <> (Some "test:3") ->
-         if __MUTAML_MUTANT__ = (Some "test:1") then 0 else 1
-     | _ -> if __MUTAML_MUTANT__ = (Some "test:2") then 3 else 2 : (a t * b t)
-                                                                     -> 
-                                                                     int)
+     | (Int, _) when not (__is_mutaml_mutant__ "test:4") ->
+         if __is_mutaml_mutant__ "test:0" then 1 else 0
+     | (_, Bool) when not (__is_mutaml_mutant__ "test:3") ->
+         if __is_mutaml_mutant__ "test:1" then 0 else 1
+     | _ -> if __is_mutaml_mutant__ "test:2" then 3 else 2 : (a t * b t) -> int)
   let _f (type a) (type b) =
     (function
-     | (Int, Int) when __MUTAML_MUTANT__ <> (Some "test:9") ->
-         if __MUTAML_MUTANT__ = (Some "test:5") then 1 else 0
-     | (Bool, Bool) when __MUTAML_MUTANT__ <> (Some "test:8") ->
-         if __MUTAML_MUTANT__ = (Some "test:6") then 0 else 1
-     | _ -> if __MUTAML_MUTANT__ = (Some "test:7") then 3 else 2 : (a t * b t)
-                                                                     -> 
-                                                                     int)
+     | (Int, Int) when not (__is_mutaml_mutant__ "test:9") ->
+         if __is_mutaml_mutant__ "test:5" then 1 else 0
+     | (Bool, Bool) when not (__is_mutaml_mutant__ "test:8") ->
+         if __is_mutaml_mutant__ "test:6" then 0 else 1
+     | _ -> if __is_mutaml_mutant__ "test:7" then 3 else 2 : (a t * b t) -> int)
 
 
 
@@ -413,20 +445,24 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ t =
     | Int: int t 
     | Bool: bool t 
   let _f : (int t * bool t) -> int =
     function
-    | (Int, _) -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
+    | (Int, _) -> if __is_mutaml_mutant__ "test:0" then 1 else 0
     | (_, Bool) -> .
     | _ -> .
   let _f : (int t * bool t) -> int =
     function
-    | (Int, _) -> if __MUTAML_MUTANT__ = (Some "test:1") then 1 else 0
+    | (Int, _) -> if __is_mutaml_mutant__ "test:1" then 1 else 0
     | (_, Bool) -> .
   let _f : (int t * bool t) -> int =
-    function | (Int, _) -> if __MUTAML_MUTANT__ = (Some "test:2") then 1 else 0
+    function | (Int, _) -> if __is_mutaml_mutant__ "test:2" then 1 else 0
 
 
 
@@ -460,6 +496,10 @@ Check that the example typechecks
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type _ typ =
     | Int: int typ 
     | String: string typ 

--- a/test/instrumentation-tests/ifthenelse.t
+++ b/test/instrumentation-tests/ifthenelse.t
@@ -17,15 +17,19 @@ Example with a simple if-then-else:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let test x =
-    if (if __MUTAML_MUTANT__ = (Some "test:0") then not x else x)
+    if (if __is_mutaml_mutant__ "test:0" then not x else x)
     then "true"
     else "false"
   let () =
-    (test (if __MUTAML_MUTANT__ = (Some "test:1") then false else true)) |>
+    (test (if __is_mutaml_mutant__ "test:1" then false else true)) |>
       print_endline
   let () =
-    (test (if __MUTAML_MUTANT__ = (Some "test:2") then true else false)) |>
+    (test (if __is_mutaml_mutant__ "test:2" then true else false)) |>
       print_endline
 
 
@@ -121,32 +125,34 @@ An example with nested ifs:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let test i =
     if
       let __MUTAML_TMP1__ =
-        i < (if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0) in
-      (if __MUTAML_MUTANT__ = (Some "test:3")
+        i < (if __is_mutaml_mutant__ "test:0" then 1 else 0) in
+      (if __is_mutaml_mutant__ "test:3"
        then not __MUTAML_TMP1__
        else __MUTAML_TMP1__)
     then "negative"
     else
       if
         (let __MUTAML_TMP0__ =
-           i > (if __MUTAML_MUTANT__ = (Some "test:1") then 1 else 0) in
-         if __MUTAML_MUTANT__ = (Some "test:2")
+           i > (if __is_mutaml_mutant__ "test:1" then 1 else 0) in
+         if __is_mutaml_mutant__ "test:2"
          then not __MUTAML_TMP0__
          else __MUTAML_TMP0__)
       then "positive"
       else "zero"
   let () =
-    (test (- (if __MUTAML_MUTANT__ = (Some "test:4") then 6 else 5))) |>
+    (test (- (if __is_mutaml_mutant__ "test:4" then 6 else 5))) |>
       print_endline
   let () =
-    (test (if __MUTAML_MUTANT__ = (Some "test:5") then 1 else 0)) |>
-      print_endline
+    (test (if __is_mutaml_mutant__ "test:5" then 1 else 0)) |> print_endline
   let () =
-    (test (if __MUTAML_MUTANT__ = (Some "test:6") then 6 else 5)) |>
-      print_endline
+    (test (if __is_mutaml_mutant__ "test:6" then 6 else 5)) |> print_endline
 
 
   $ _build/default/test.bc

--- a/test/instrumentation-tests/match-omit-case.t
+++ b/test/instrumentation-tests/match-omit-case.t
@@ -87,13 +87,17 @@ Make an .ml-file:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let identify_char c =
     ((match c with
-      | 'a'..'z' when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | 'a'..'z' when not (__is_mutaml_mutant__ "test:2") ->
           "lower-case letter"
-      | 'A'..'Z' when __MUTAML_MUTANT__ <> (Some "test:1") ->
+      | 'A'..'Z' when not (__is_mutaml_mutant__ "test:1") ->
           "upper-case letter"
-      | '0'..'9' when __MUTAML_MUTANT__ <> (Some "test:0") -> "digit"
+      | '0'..'9' when not (__is_mutaml_mutant__ "test:0") -> "digit"
       | _ -> "other")
     [@ocaml.warning "-8"])
   let () = print_endline (identify_char 'e')
@@ -220,17 +224,20 @@ Test that same example with a variable will be instrumented with this mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let identify_char c =
     ((match c with
-      | 'a'..'z' when __MUTAML_MUTANT__ <> (Some "test:3") ->
+      | 'a'..'z' when not (__is_mutaml_mutant__ "test:3") ->
           "lower-case letter"
-      | 'A'..'Z' when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | 'A'..'Z' when not (__is_mutaml_mutant__ "test:2") ->
           "upper-case letter"
-      | '0'..'9' when __MUTAML_MUTANT__ <> (Some "test:1") -> "digit"
+      | '0'..'9' when not (__is_mutaml_mutant__ "test:1") -> "digit"
       | c ->
           "other char: " ^
-            (String.make (if __MUTAML_MUTANT__ = (Some "test:0") then 0 else 1)
-               c))
+            (String.make (if __is_mutaml_mutant__ "test:0" then 0 else 1) c))
     [@ocaml.warning "-8"])
   let () = print_endline (identify_char 'e')
   let () = print_endline (identify_char 'U')
@@ -376,10 +383,14 @@ Another test w/tuples and wildcards:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let prioritize p fallback =
     match p with
-    | (Some x, _) when __MUTAML_MUTANT__ <> (Some "test:1") -> x
-    | (_, Some y) when __MUTAML_MUTANT__ <> (Some "test:0") -> y
+    | (Some x, _) when not (__is_mutaml_mutant__ "test:1") -> x
+    | (_, Some y) when not (__is_mutaml_mutant__ "test:0") -> y
     | (_, _) -> fallback
   ;;(prioritize ((Some "1st"), (Some "2nd")) "3rd") |> print_endline
   ;;(prioritize ((Some "1st"), None) "3rd") |> print_endline
@@ -481,6 +492,10 @@ Same example without wildcards will not be instrumented with this mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let prioritize p fallback =
     match p with
     | (Some x, _) -> x
@@ -522,28 +537,29 @@ A test with exceptions:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let my_find h key =
     match Hashtbl.find h key with
-    | Some "" when __MUTAML_MUTANT__ <> (Some "test:1") ->
+    | Some "" when not (__is_mutaml_mutant__ "test:1") ->
         "Present with weird special case Some \"\""
-    | Some s when __MUTAML_MUTANT__ <> (Some "test:0") ->
+    | Some s when not (__is_mutaml_mutant__ "test:0") ->
         "Present with Some " ^ s
     | _ -> "Present with None"
     | exception Not_found -> "Key not present"
-  let h =
-    Hashtbl.create (if __MUTAML_MUTANT__ = (Some "test:2") then 43 else 42)
-  ;;Hashtbl.add h (if __MUTAML_MUTANT__ = (Some "test:3") then 1 else 0) None
-  ;;Hashtbl.add h (if __MUTAML_MUTANT__ = (Some "test:4") then 0 else 1)
-      (Some "1")
-  ;;Hashtbl.add h (if __MUTAML_MUTANT__ = (Some "test:5") then 3 else 2)
-      (Some "")
-  ;;(my_find h (if __MUTAML_MUTANT__ = (Some "test:6") then 1 else 0)) |>
+  let h = Hashtbl.create (if __is_mutaml_mutant__ "test:2" then 43 else 42)
+  ;;Hashtbl.add h (if __is_mutaml_mutant__ "test:3" then 1 else 0) None
+  ;;Hashtbl.add h (if __is_mutaml_mutant__ "test:4" then 0 else 1) (Some "1")
+  ;;Hashtbl.add h (if __is_mutaml_mutant__ "test:5" then 3 else 2) (Some "")
+  ;;(my_find h (if __is_mutaml_mutant__ "test:6" then 1 else 0)) |>
       print_endline
-  ;;(my_find h (if __MUTAML_MUTANT__ = (Some "test:7") then 0 else 1)) |>
+  ;;(my_find h (if __is_mutaml_mutant__ "test:7" then 0 else 1)) |>
       print_endline
-  ;;(my_find h (if __MUTAML_MUTANT__ = (Some "test:8") then 3 else 2)) |>
+  ;;(my_find h (if __is_mutaml_mutant__ "test:8" then 3 else 2)) |>
       print_endline
-  ;;(my_find h (if __MUTAML_MUTANT__ = (Some "test:9") then 4 else 3)) |>
+  ;;(my_find h (if __is_mutaml_mutant__ "test:9" then 4 else 3)) |>
       print_endline
 
 

--- a/test/instrumentation-tests/match.t
+++ b/test/instrumentation-tests/match.t
@@ -82,6 +82,10 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let () =
     match !Sys.interactive with
     | false -> print_endline "Running in batch mode"
@@ -105,9 +109,13 @@ Same example but with GADT-unsafe mutations enabled:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let () =
     ((match !Sys.interactive with
-      | false when __MUTAML_MUTANT__ <> (Some "test:0") ->
+      | false when not (__is_mutaml_mutant__ "test:0") ->
           print_endline "Running in batch mode"
       | false | true -> print_endline "Running interactively")
     [@ocaml.warning "-8"])
@@ -147,6 +155,10 @@ Another example:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type t =
     | A 
     | B 
@@ -179,14 +191,18 @@ Same example but with GADT-unsafe mutations enabled:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type t =
     | A 
     | B 
     | C 
   let f x =
     ((match x with
-      | A when __MUTAML_MUTANT__ <> (Some "test:1") -> "A"
-      | A | B when __MUTAML_MUTANT__ <> (Some "test:0") -> "B"
+      | A when not (__is_mutaml_mutant__ "test:1") -> "A"
+      | A | B when not (__is_mutaml_mutant__ "test:0") -> "B"
       | B | C -> "C")
     [@ocaml.warning "-8"])
   let () = (f A) |> print_endline
@@ -301,12 +317,16 @@ Instead we trigger the collapse-consecutive-patterns mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let rec count_zeroes xs =
     ((match xs with
-      | [] -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-      | 0::xs when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | [] -> if __is_mutaml_mutant__ "test:0" then 1 else 0
+      | 0::xs when not (__is_mutaml_mutant__ "test:2") ->
           let __MUTAML_TMP0__ = count_zeroes xs in
-          if __MUTAML_MUTANT__ = (Some "test:1")
+          if __is_mutaml_mutant__ "test:1"
           then __MUTAML_TMP0__
           else 1 + __MUTAML_TMP0__
       | 0::xs | _::xs -> count_zeroes xs)
@@ -314,22 +334,22 @@ Instead we trigger the collapse-consecutive-patterns mutation:
   let () = (count_zeroes []) |> (Printf.printf "%i\n")
   let () =
     (count_zeroes
-       [if __MUTAML_MUTANT__ = (Some "test:3") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:4") then 1 else 0])
+       [if __is_mutaml_mutant__ "test:3" then 0 else 1;
+       if __is_mutaml_mutant__ "test:4" then 1 else 0])
       |> (Printf.printf "%i\n")
   let () =
     (count_zeroes
-       [if __MUTAML_MUTANT__ = (Some "test:5") then 1 else 0;
-       if __MUTAML_MUTANT__ = (Some "test:6") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:7") then 1 else 0])
+       [if __is_mutaml_mutant__ "test:5" then 1 else 0;
+       if __is_mutaml_mutant__ "test:6" then 0 else 1;
+       if __is_mutaml_mutant__ "test:7" then 1 else 0])
       |> (Printf.printf "%i\n")
   let () =
     (count_zeroes
-       [if __MUTAML_MUTANT__ = (Some "test:8") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:9") then 1 else 0;
-       if __MUTAML_MUTANT__ = (Some "test:10") then 1 else 0;
-       if __MUTAML_MUTANT__ = (Some "test:11") then 0 else 1;
-       if __MUTAML_MUTANT__ = (Some "test:12") then 1 else 0])
+       [if __is_mutaml_mutant__ "test:8" then 0 else 1;
+       if __is_mutaml_mutant__ "test:9" then 1 else 0;
+       if __is_mutaml_mutant__ "test:10" then 1 else 0;
+       if __is_mutaml_mutant__ "test:11" then 0 else 1;
+       if __is_mutaml_mutant__ "test:12" then 1 else 0])
       |> (Printf.printf "%i\n")
 
   $ _build/default/test.bc
@@ -595,6 +615,10 @@ Another example that would trigger merge-of-consecutive-patterns w/GADT true:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type binop =
     | Add 
     | Mul 
@@ -609,18 +633,17 @@ Another example that would trigger merge-of-consecutive-patterns w/GADT true:
     | Binop (ae0, Add, ae1) ->
         let v0 = interpret xval ae0 in
         let v1 = interpret xval ae1 in
-        if __MUTAML_MUTANT__ = (Some "test:0") then v0 - v1 else v0 + v1
+        if __is_mutaml_mutant__ "test:0" then v0 - v1 else v0 + v1
     | Binop (ae0, Mul, ae1) ->
         let v0 = interpret xval ae0 in
         let v1 = interpret xval ae1 in
-        if __MUTAML_MUTANT__ = (Some "test:1") then v0 + v1 else v0 * v1
+        if __is_mutaml_mutant__ "test:1" then v0 + v1 else v0 * v1
   let () =
-    (interpret (if __MUTAML_MUTANT__ = (Some "test:2") then 3 else 2)
+    (interpret (if __is_mutaml_mutant__ "test:2" then 3 else 2)
        (Binop
-          ((Lit (if __MUTAML_MUTANT__ = (Some "test:3") then 0 else 1)), Add,
+          ((Lit (if __is_mutaml_mutant__ "test:3" then 0 else 1)), Add,
             (Binop
-               (X, Mul,
-                 (Lit (if __MUTAML_MUTANT__ = (Some "test:4") then 4 else 3)))))))
+               (X, Mul, (Lit (if __is_mutaml_mutant__ "test:4" then 4 else 3)))))))
       |> (Printf.printf "1 + x*3 = %i\n")
 
 
@@ -742,6 +765,10 @@ Same example that triggers merge-of-consecutive-patterns w/GADT false:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type binop =
     | Add 
     | Mul 
@@ -753,22 +780,21 @@ Same example that triggers merge-of-consecutive-patterns w/GADT false:
     ((match ae with
       | X -> xval
       | Lit i -> i
-      | Binop (ae0, Add, ae1) when __MUTAML_MUTANT__ <> (Some "test:2") ->
+      | Binop (ae0, Add, ae1) when not (__is_mutaml_mutant__ "test:2") ->
           let v0 = interpret xval ae0 in
           let v1 = interpret xval ae1 in
-          if __MUTAML_MUTANT__ = (Some "test:0") then v0 - v1 else v0 + v1
+          if __is_mutaml_mutant__ "test:0" then v0 - v1 else v0 + v1
       | Binop (ae0, Add, ae1) | Binop (ae0, Mul, ae1) ->
           let v0 = interpret xval ae0 in
           let v1 = interpret xval ae1 in
-          if __MUTAML_MUTANT__ = (Some "test:1") then v0 + v1 else v0 * v1)
+          if __is_mutaml_mutant__ "test:1" then v0 + v1 else v0 * v1)
     [@ocaml.warning "-8"])
   let () =
-    (interpret (if __MUTAML_MUTANT__ = (Some "test:3") then 3 else 2)
+    (interpret (if __is_mutaml_mutant__ "test:3" then 3 else 2)
        (Binop
-          ((Lit (if __MUTAML_MUTANT__ = (Some "test:4") then 0 else 1)), Add,
+          ((Lit (if __is_mutaml_mutant__ "test:4" then 0 else 1)), Add,
             (Binop
-               (X, Mul,
-                 (Lit (if __MUTAML_MUTANT__ = (Some "test:5") then 4 else 3)))))))
+               (X, Mul, (Lit (if __is_mutaml_mutant__ "test:5" then 4 else 3)))))))
       |> (Printf.printf "1 + x*3 = %i\n")
 
 
@@ -916,22 +942,25 @@ Another example that would trigger merge-of-consecutive-patterns:
 
   $ export MUTAML_SEED=896745231
   $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 > output.txt
-  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 21 output.txt
+  $ head -n 4 output.txt && echo "ERROR MESSAGE" && tail -n 24 output.txt
   Running mutaml instrumentation on "test.ml"
   Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
   Created 6 mutations of test.ml
   Writing mutation info to test.muts
   ERROR MESSAGE
-  
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let _f x =
     match x with
-    | [||] -> if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-    | [|_|] -> if __MUTAML_MUTANT__ = (Some "test:1") then 0 else 1
-    | [|_;_|] -> if __MUTAML_MUTANT__ = (Some "test:2") then 3 else 2
-    | [|_;_;_|] -> if __MUTAML_MUTANT__ = (Some "test:3") then 4 else 3
-    | _ when if __MUTAML_MUTANT__ = (Some "test:4") then false else true ->
-        if __MUTAML_MUTANT__ = (Some "test:5") then 1001 else 1000
+    | [||] -> if __is_mutaml_mutant__ "test:0" then 1 else 0
+    | [|_|] -> if __is_mutaml_mutant__ "test:1" then 0 else 1
+    | [|_;_|] -> if __is_mutaml_mutant__ "test:2" then 3 else 2
+    | [|_;_;_|] -> if __is_mutaml_mutant__ "test:3" then 4 else 3
+    | _ when if __is_mutaml_mutant__ "test:4" then false else true ->
+        if __is_mutaml_mutant__ "test:5" then 1001 else 1000
   File "test.ml", lines 1-6, characters 11-23:
   1 | ...........match x with
   2 |   | [| |] -> 0
@@ -961,18 +990,21 @@ Same example but with GADT false:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let _f x =
     ((match x with
-      | [||] when __MUTAML_MUTANT__ <> (Some "test:8") ->
-          if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0
-      | [||] | [|_|] when __MUTAML_MUTANT__ <> (Some "test:7") ->
-          if __MUTAML_MUTANT__ = (Some "test:1") then 0 else 1
-      | [|_|] | [|_;_|] when __MUTAML_MUTANT__ <> (Some "test:6") ->
-          if __MUTAML_MUTANT__ = (Some "test:2") then 3 else 2
-      | [|_;_|] | [|_;_;_|] ->
-          if __MUTAML_MUTANT__ = (Some "test:3") then 4 else 3
-      | _ when if __MUTAML_MUTANT__ = (Some "test:4") then false else true ->
-          if __MUTAML_MUTANT__ = (Some "test:5") then 1001 else 1000)
+      | [||] when not (__is_mutaml_mutant__ "test:8") ->
+          if __is_mutaml_mutant__ "test:0" then 1 else 0
+      | [||] | [|_|] when not (__is_mutaml_mutant__ "test:7") ->
+          if __is_mutaml_mutant__ "test:1" then 0 else 1
+      | [|_|] | [|_;_|] when not (__is_mutaml_mutant__ "test:6") ->
+          if __is_mutaml_mutant__ "test:2" then 3 else 2
+      | [|_;_|] | [|_;_;_|] -> if __is_mutaml_mutant__ "test:3" then 4 else 3
+      | _ when if __is_mutaml_mutant__ "test:4" then false else true ->
+          if __is_mutaml_mutant__ "test:5" then 1001 else 1000)
     [@ocaml.warning "-8"])
 
   $ unset MUTAML_GADT

--- a/test/instrumentation-tests/open_module.t
+++ b/test/instrumentation-tests/open_module.t
@@ -55,20 +55,27 @@ Test mutation of an 'assert false':
   Writing mutation info to a.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let () = Printf.printf "hello from A!\n"
-  let x = if __MUTAML_MUTANT__ = (Some "a:0") then 4 else 3
+  let x = if __is_mutaml_mutant__ "a:0" then 4 else 3
   let res =
-    (let __MUTAML_TMP0__ = if __MUTAML_MUTANT__ = (Some "a:1") then 3 else 2 in
-     if __MUTAML_MUTANT__ = (Some "a:2")
+    (let __MUTAML_TMP0__ = if __is_mutaml_mutant__ "a:1" then 3 else 2 in
+     if __is_mutaml_mutant__ "a:2"
      then __MUTAML_TMP0__ + x
-     else __MUTAML_TMP0__ * x) =
-      (if __MUTAML_MUTANT__ = (Some "a:3") then 7 else 6)
+     else __MUTAML_TMP0__ * x) = (if __is_mutaml_mutant__ "a:3" then 7 else 6)
   let () = assert res
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   open A
   let () = Printf.printf "hello from B!\n"
-  let res = x = (if __MUTAML_MUTANT__ = (Some "b:0") then 2 else 1 + 2)
+  let res = x = (if __is_mutaml_mutant__ "b:0" then 2 else 1 + 2)
   let () = assert res
 
 

--- a/test/instrumentation-tests/records.t
+++ b/test/instrumentation-tests/records.t
@@ -23,13 +23,17 @@ An simple record example
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   type t = {
     x: int ;
     y: int }
   let f =
     function
-    | { x = v; y = 0 } when __MUTAML_MUTANT__ <> (Some "test:2") -> v
-    | { x = 0; y = v } when __MUTAML_MUTANT__ <> (Some "test:1") -> v
-    | { x; y } -> if __MUTAML_MUTANT__ = (Some "test:0") then x - y else x + y
+    | { x = v; y = 0 } when not (__is_mutaml_mutant__ "test:2") -> v
+    | { x = 0; y = v } when not (__is_mutaml_mutant__ "test:1") -> v
+    | { x; y } -> if __is_mutaml_mutant__ "test:0" then x - y else x + y
 
 

--- a/test/instrumentation-tests/sequence.t
+++ b/test/instrumentation-tests/sequence.t
@@ -30,11 +30,15 @@ Test a sequence mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let f () =
-    let c = ref (if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0) in
-    if __MUTAML_MUTANT__ = (Some "test:3") then () else incr c;
-    if __MUTAML_MUTANT__ = (Some "test:2") then () else incr c;
-    if __MUTAML_MUTANT__ = (Some "test:1") then () else incr c;
+    let c = ref (if __is_mutaml_mutant__ "test:0" then 1 else 0) in
+    if __is_mutaml_mutant__ "test:3" then () else incr c;
+    if __is_mutaml_mutant__ "test:2" then () else incr c;
+    if __is_mutaml_mutant__ "test:1" then () else incr c;
     !c
   ;;assert ((f ()) = 3)
 
@@ -93,11 +97,15 @@ Test uncaught sequence mutation:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let f () =
-    let c = ref (if __MUTAML_MUTANT__ = (Some "test:0") then 1 else 0) in
-    if __MUTAML_MUTANT__ = (Some "test:3") then () else incr c;
-    if __MUTAML_MUTANT__ = (Some "test:2") then () else incr c;
-    if __MUTAML_MUTANT__ = (Some "test:1") then () else incr c;
+    let c = ref (if __is_mutaml_mutant__ "test:0" then 1 else 0) in
+    if __is_mutaml_mutant__ "test:3" then () else incr c;
+    if __is_mutaml_mutant__ "test:2" then () else incr c;
+    if __is_mutaml_mutant__ "test:1" then () else incr c;
     !c
   ;;assert ((f ()) > 0)
 

--- a/test/instrumentation-tests/simple_print.t
+++ b/test/instrumentation-tests/simple_print.t
@@ -30,12 +30,15 @@ Compile with instrumentation and filter result:
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
   let () =
     print_string
-      (string_of_bool
-         (if __MUTAML_MUTANT__ = (Some "test:0") then false else true))
+      (string_of_bool (if __is_mutaml_mutant__ "test:0" then false else true))
   let () = print_newline ()
-  let () = print_int (if __MUTAML_MUTANT__ = (Some "test:1") then 6 else 5)
+  let () = print_int (if __is_mutaml_mutant__ "test:1" then 6 else 5)
   let () = print_newline ()
 
 

--- a/test/issue-newlines.t/run.t
+++ b/test/issue-newlines.t/run.t
@@ -44,7 +44,11 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let add a b = if __MUTAML_MUTANT__ = (Some "test:0") then a - b else a + b
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let add a b = if __is_mutaml_mutant__ "test:0" then a - b else a + b
   ;;assert ((add 4 3) >= 0)
 
   $ ls _build

--- a/test/issue-pattern-match.t/run.t
+++ b/test/issue-pattern-match.t/run.t
@@ -50,14 +50,17 @@ Set seed and (full) mutation rate as environment variables, for repeatability
   Writing mutation info to test.muts
   
   let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
-  let accepted_codes n =
-    n = (if __MUTAML_MUTANT__ = (Some "test:0") then 43 else 42)
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let accepted_codes n = n = (if __is_mutaml_mutant__ "test:0" then 43 else 42)
   let make status =
     let open Unix in
       let exit_status =
         ((match status with
           | WEXITED n when
-              (accepted_codes n) && (__MUTAML_MUTANT__ <> (Some "test:1")) ->
+              (accepted_codes n) && (not (__is_mutaml_mutant__ "test:1")) ->
               Ok n
           | WEXITED n -> Error (Printf.sprintf "Exited %n" n)
           | WSIGNALED n -> Error (Printf.sprintf "Signaled %n" n)

--- a/test/issue-stdlib-equal.t/run.t
+++ b/test/issue-stdlib-equal.t/run.t
@@ -1,0 +1,96 @@
+Let us try something:
+
+  $ ls ../filter_dune_build.sh
+  ../filter_dune_build.sh
+
+Create the central file overriding polymorphic equality:
+  $ cat > test.ml << EOF
+  > let (=) = Int.equal
+  > 
+  > let add a b = a + b
+  > ;;
+  > assert (add 4 3 >= 0)
+  > EOF
+
+Create the dune files:
+  $ cat > dune-project << EOF
+  > (lang dune 2.9)
+  > EOF
+
+  $ cat > dune <<'EOF'
+  > (executable
+  >  (name test)
+  >  (ocamlc_flags -dsource)
+  >  (instrumentation (backend mutaml))
+  > )
+  > EOF
+
+Check that files were created as expected:
+  $ ls dune* test.ml
+  dune
+  dune-project
+  test.ml
+
+Set seed and (full) mutation rate as environment variables, for repeatability
+  $ export MUTAML_SEED=896745231
+  $ export MUTAML_MUT_RATE=100
+
+  $ ../filter_dune_build.sh ./test.exe --instrument-with mutaml
+  Running mutaml instrumentation on "test.ml"
+  Randomness seed: 896745231   Mutation rate: 100   GADTs enabled: true
+  Created 1 mutation of test.ml
+  Writing mutation info to test.muts
+  
+  let __MUTAML_MUTANT__ = Stdlib.Sys.getenv_opt "MUTAML_MUTANT"
+  let __is_mutaml_mutant__ m =
+    match __MUTAML_MUTANT__ with
+    | None -> false
+    | Some mutant -> String.equal m mutant
+  let (=) = Int.equal
+  let add a b = if __is_mutaml_mutant__ "test:0" then a - b else a + b
+  ;;assert ((add 4 3) >= 0)
+
+  $ ls _build
+  default
+  log
+
+  $ ls _build/default
+  mutaml-mut-files.txt
+  test.exe
+  test.ml
+  test.muts
+  test.pp.ml
+
+  $ mutaml-runner _build/default/test.exe
+  read mut file test.muts
+  Testing mutant test:0 ... passed
+  Writing report data to mutaml-report.json
+
+  $ mutaml-report
+  Attempting to read from mutaml-report.json...
+  
+  Mutaml report summary:
+  ----------------------
+  
+   target                          #mutations      #failed      #timeouts      #passed 
+   -------------------------------------------------------------------------------------
+   test.ml                                1       0.0%    0     0.0%    0   100.0%    1
+   =====================================================================================
+  
+  Mutation programs passing the test suite:
+  -----------------------------------------
+  
+  Mutation "test.ml-mutant0" passed (see "_mutations/test.ml-mutant0.output"):
+  
+  --- test.ml
+  +++ test.ml-mutant0
+  @@ -1,5 +1,5 @@
+   let (=) = Int.equal
+   
+  -let add a b = a + b
+  +let add a b = a - b
+   ;;
+   assert (add 4 3 >= 0)
+  
+  ---------------------------------------------------------------------------
+  


### PR DESCRIPTION
The second issue of #28 is that the ppx is emitting a polymorphic comparison `=` between `string option`s to detect which mutant we are running. After `open Core` `=` is however redefined to an integer comparison function `int -> int -> bool`, thus leading to a type error in the generated code.

This PR therefore changes the mutation strategy by emitting a helper function `__is_mutaml_mutant__` in the preamble, which just relies on `String.equal`, available in both `Stdlib` and `Core`.

The meat is in the first commit, updating the ppx.
The second commit adds a regression cram test.
The third commit just updates and adjusts the existing cram tests.
