### PR TITLE
Support ppxlib.0.34 and runtest on OCaml 5.3

### DIFF
--- a/mutaml.opam
+++ b/mutaml.opam
@@ -42,7 +42,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & arch != "ppc64" & arch != "riscv64" & ocaml:version < "5.3"}
+    "@runtest" {with-test & arch != "ppc64" & arch != "riscv64"}
     "@doc" {with-doc}
   ]
 ]

--- a/test/instrumentation-tests/assert.t
+++ b/test/instrumentation-tests/assert.t
@@ -12,36 +12,36 @@ Make an .ml-file:
 Quick interlude:  This can be useful to observe the parse tree:
 ---------------------------------------------------------------
 
-  $ ocamlc -dparsetree test.ml
-  [
-    structure_item (test.ml[1,0+0]..[3,48+22])
-      Pstr_value Nonrec
-      [
-        <def>
-          pattern (test.ml[1,0+4]..[1,0+7])
-            Ppat_var "foo" (test.ml[1,0+4]..[1,0+7])
-          expression (test.ml[1,0+10]..[3,48+22])
-            Pexp_match
-            expression (test.ml[1,0+16]..[1,0+29])
-              Pexp_ident "Sys.word_size" (test.ml[1,0+16]..[1,0+29])
-            [
-              <case>
-                pattern (test.ml[2,35+4]..[2,35+6])
-                  Ppat_constant PConst_int (32,None)
-                expression (test.ml[2,35+10]..[2,35+12])
-                  Pexp_constant PConst_int (32,None)
-              <case>
-                pattern (test.ml[3,48+4]..[3,48+5])
-                  Ppat_any
-                expression (test.ml[3,48+10]..[3,48+22])
-                  Pexp_assert
-                  expression (test.ml[3,48+17]..[3,48+22])
-                    Pexp_construct "false" (test.ml[3,48+17]..[3,48+22])
-                    None
-            ]
-      ]
-  ]
-  
+;  $ ocamlc -dparsetree test.ml
+;  [
+;    structure_item (test.ml[1,0+0]..[3,48+22])
+;      Pstr_value Nonrec
+;      [
+;        <def>
+;          pattern (test.ml[1,0+4]..[1,0+7])
+;            Ppat_var "foo" (test.ml[1,0+4]..[1,0+7])
+;          expression (test.ml[1,0+10]..[3,48+22])
+;            Pexp_match
+;            expression (test.ml[1,0+16]..[1,0+29])
+;              Pexp_ident "Sys.word_size" (test.ml[1,0+16]..[1,0+29])
+;            [
+;              <case>
+;                pattern (test.ml[2,35+4]..[2,35+6])
+;                  Ppat_constant PConst_int (32,None)
+;                expression (test.ml[2,35+10]..[2,35+12])
+;                  Pexp_constant PConst_int (32,None)
+;              <case>
+;                pattern (test.ml[3,48+4]..[3,48+5])
+;                  Ppat_any
+;                expression (test.ml[3,48+10]..[3,48+22])
+;                  Pexp_assert
+;                  expression (test.ml[3,48+17]..[3,48+22])
+;                    Pexp_construct "false" (test.ml[3,48+17]..[3,48+22])
+;                    None
+;            ]
+;      ]
+;  ]
+
 ----------------------------------------------------------------------------------
 Test mutation of the 'assert false':
 ----------------------------------------------------------------------------------

--- a/test/instrumentation-tests/match.t
+++ b/test/instrumentation-tests/match.t
@@ -11,61 +11,59 @@ Make an .ml-file:
 
 This gets parsed to the following syntax tree:
 
-  $ ocamlc -dparsetree test.ml
-  [
-    structure_item (test.ml[1,0+0]..[3,88+50])
-      Pstr_value Nonrec
-      [
-        <def>
-          pattern (test.ml[1,0+4]..[1,0+6])
-            Ppat_construct "()" (test.ml[1,0+4]..[1,0+6])
-            None
-          expression (test.ml[1,0+9]..[3,88+50])
-            Pexp_match
-            expression (test.ml[1,0+15]..[1,0+31])
-              Pexp_apply
-              expression (test.ml[1,0+15]..[1,0+16])
-                Pexp_ident "!" (test.ml[1,0+15]..[1,0+16])
-              [
-                <arg>
-                Nolabel
-                  expression (test.ml[1,0+16]..[1,0+31])
-                    Pexp_ident "Sys.interactive" (test.ml[1,0+16]..[1,0+31])
-              ]
-            [
-              <case>
-                pattern (test.ml[2,37+4]..[2,37+9])
-                  Ppat_construct "false" (test.ml[2,37+4]..[2,37+9])
-                  None
-                expression (test.ml[2,37+13]..[2,37+50])
-                  Pexp_apply
-                  expression (test.ml[2,37+13]..[2,37+26])
-                    Pexp_ident "print_endline" (test.ml[2,37+13]..[2,37+26])
-                  [
-                    <arg>
-                    Nolabel
-                      expression (test.ml[2,37+27]..[2,37+50])
-                        Pexp_constant PConst_string("Running in batch mode",(test.ml[2,37+28]..[2,37+49]),None)
-                  ]
-              <case>
-                pattern (test.ml[3,88+4]..[3,88+8])
-                  Ppat_construct "true" (test.ml[3,88+4]..[3,88+8])
-                  None
-                expression (test.ml[3,88+13]..[3,88+50])
-                  Pexp_apply
-                  expression (test.ml[3,88+13]..[3,88+26])
-                    Pexp_ident "print_endline" (test.ml[3,88+13]..[3,88+26])
-                  [
-                    <arg>
-                    Nolabel
-                      expression (test.ml[3,88+27]..[3,88+50])
-                        Pexp_constant PConst_string("Running interactively",(test.ml[3,88+28]..[3,88+49]),None)
-                  ]
-            ]
-      ]
-  ]
-  
-
+;  $ ocamlc -dparsetree test.ml
+;  [
+;    structure_item (test.ml[1,0+0]..[3,88+50])
+;      Pstr_value Nonrec
+;      [
+;        <def>
+;          pattern (test.ml[1,0+4]..[1,0+6])
+;            Ppat_construct "()" (test.ml[1,0+4]..[1,0+6])
+;            None
+;          expression (test.ml[1,0+9]..[3,88+50])
+;            Pexp_match
+;            expression (test.ml[1,0+15]..[1,0+31])
+;              Pexp_apply
+;              expression (test.ml[1,0+15]..[1,0+16])
+;                Pexp_ident "!" (test.ml[1,0+15]..[1,0+16])
+;              [
+;                <arg>
+;                Nolabel
+;                  expression (test.ml[1,0+16]..[1,0+31])
+;                    Pexp_ident "Sys.interactive" (test.ml[1,0+16]..[1,0+31])
+;              ]
+;            [
+;              <case>
+;                pattern (test.ml[2,37+4]..[2,37+9])
+;                  Ppat_construct "false" (test.ml[2,37+4]..[2,37+9])
+;                  None
+;                expression (test.ml[2,37+13]..[2,37+50])
+;                  Pexp_apply
+;                  expression (test.ml[2,37+13]..[2,37+26])
+;                    Pexp_ident "print_endline" (test.ml[2,37+13]..[2,37+26])
+;                  [
+;                    <arg>
+;                    Nolabel
+;                      expression (test.ml[2,37+27]..[2,37+50])
+;                        Pexp_constant PConst_string("Running in batch mode",(test.ml[2,37+28]..[2,37+49]),None)
+;                  ]
+;              <case>
+;                pattern (test.ml[3,88+4]..[3,88+8])
+;                  Ppat_construct "true" (test.ml[3,88+4]..[3,88+8])
+;                  None
+;                expression (test.ml[3,88+13]..[3,88+50])
+;                  Pexp_apply
+;                  expression (test.ml[3,88+13]..[3,88+26])
+;                    Pexp_ident "print_endline" (test.ml[3,88+13]..[3,88+26])
+;                  [
+;                    <arg>
+;                    Nolabel
+;                      expression (test.ml[3,88+27]..[3,88+50])
+;                        Pexp_constant PConst_string("Running interactively",(test.ml[3,88+28]..[3,88+49]),None)
+;                  ]
+;            ]
+;      ]
+;  ]
 
 
 Let's first compile and run the example

--- a/test/negative-tests/ppx-negtests.t
+++ b/test/negative-tests/ppx-negtests.t
@@ -228,7 +228,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | grep -v "no-merge" | grep -v "Embed errors"
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | grep -v "no-merge\|Embed errors\|keywords"
   ppx.exe [extra_args] [<files>]
     -as-ppx                     Run as a -ppx rewriter (must be the first argument)
     --as-ppx                    Same as -as-ppx


### PR DESCRIPTION
ppxlib.0.34 added -keywords options, thus creating a different cram test output