### PR TITLE
Remove `which` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,6 @@
   (ppx_yojson_conv (>= 0.14.0))
   stdlib-random
   conf-timeout
-  conf-which
   conf-diffutils
   ;; transitive lower versions to avoid CI errors
   (ocaml-compiler-libs (>= v0.12.0))

--- a/mutaml.opam
+++ b/mutaml.opam
@@ -23,7 +23,6 @@ depends: [
   "ppx_yojson_conv" {>= "0.14.0"}
   "stdlib-random"
   "conf-timeout"
-  "conf-which"
   "conf-diffutils"
   "ocaml-compiler-libs" {>= "v0.12.0"}
   "ppx_derivers" {>= "1.2.1"}

--- a/src/runner/runner.ml
+++ b/src/runner/runner.ml
@@ -153,7 +153,7 @@ let rec run_all_mutation_tests test_cmd muts = match muts with
 (** Executable entry point *)
 
 let () =
-  if 0 <> Sys.command ("which " ^ timeout_cmd ^ " > /dev/null")
+  if 0 <> Sys.command ("command -v " ^ timeout_cmd ^ " > /dev/null")
   then fail_and_exit ("Could not find time-out command: " ^ timeout_cmd)
   else
     let test_cmd = ref "" in


### PR DESCRIPTION
This PR removes the dependency on `which` reflected in `conf-which`, by instead relying on the POSIX-compliant `command -v` which I just learned about from https://github.com/ocaml/opam-repository/issues/18452
