### PR TITLE
Avoid RE alternation to run cleanly on OpenBSD too

### DIFF
--- a/test/negative-tests/ppx-negtests.t
+++ b/test/negative-tests/ppx-negtests.t
@@ -228,7 +228,7 @@ Instrument and check that it was received
   > )
   > EOF
 
-  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | grep -v "use-compiler-pp\|no-merge\|Embed errors\|keywords"
+  $ bash ../filter_dune_build.sh ./test.bc --instrument-with mutaml 2>&1 | grep -v "use-compiler-pp" | grep -v "no-merge" | grep -v "Embed errors" | grep -v "keywords"
   ppx.exe [extra_args] [<files>]
     -as-ppx                     Run as a -ppx rewriter (must be the first argument)
     --as-ppx                    Same as -as-ppx


### PR DESCRIPTION
This is not pretty, but it is not particularly important either :shrug: 

As this seems to be the last error on the (experimental) OpenBSD ocaml-ci runners, hopefully this will turn them green too... :crossed_fingers: 