### PR TITLE
Avoid opam file patching

### DIFF
--- a/mutaml.opam
+++ b/mutaml.opam
@@ -31,6 +31,7 @@ depends: [
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]
+dev-repo: "git+https://github.com/jmid/mutaml.git"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -45,5 +46,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/jmid/mutaml.git"
 x-maintenance-intent: ["(latest)"]

--- a/mutaml.opam.template
+++ b/mutaml.opam.template
@@ -1,1 +1,15 @@
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & arch != "ppc64" & arch != "riscv64"}
+    "@doc" {with-doc}
+  ]
+]
 x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
The opam linting is failing because of the patch after the opam file has been generated.
This PR therefore adds the ppc64+riscv runtest disabling to the opam file template to avoid the hack - and the red CI light.