### PR TITLE
Patch `ppx_yojson_conv` version in opam file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 Next release
 ------------
 
-- ...
+- Patch `ppx_yojson_conv` dependency which was missing a `v`-prefix
+- Introduce a `mutaml.opam.template` to avoid opam linting failure #41
+- Adjust RE to support `runtest` on OpenBSD too #40
+- Remove `which` and `conf-which` dependency #39
+- Support ppxlib.0.34 and runtest on OCaml 5.3 #36
 
 0.3
 ---

--- a/mutaml.opam
+++ b/mutaml.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.12.0"}
   "ppxlib" {>= "0.28.0"}
-  "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_yojson_conv" {>= "v0.14.0"}
   "stdlib-random"
   "conf-timeout"
   "conf-diffutils"


### PR DESCRIPTION
`ppx_yojson_conv` uses a version scheme with a `v`-prefix, which was missing from the opam file's dependencies.
While at it, this PR also updates the `CHANGES` list.