### PR TITLE
Use dune's built-in maintenance-intent support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Next release
 ------------
 
+- Use dune.3.18 support to generate `x-maintenance-intent` entry
 - Patch `ppx_yojson_conv` dependency which was missing a `v`-prefix
 - Introduce a `mutaml.opam.template` to avoid opam linting failure #41
 - Adjust RE to support `runtest` on OpenBSD too #40

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
  (depends
   (ocaml (>= 4.12.0))
   (ppxlib (>= 0.28.0))
-  (ppx_yojson_conv (>= 0.14.0))
+  (ppx_yojson_conv (>= v0.14.0))
   stdlib-random
   conf-timeout
   conf-diffutils

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.0)
+(lang dune 3.18)
 
 (name mutaml)
 
@@ -36,4 +36,6 @@
   (ppx_derivers (>= 1.2.1))
   (yojson (>= 2.0.0))
   (ppx_deriving :with-test)
-  (ounit2 :with-test)))
+  (ounit2 :with-test))
+ (maintenance_intent "(latest)")
+)

--- a/mutaml.opam
+++ b/mutaml.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/jmid/mutaml"
 doc: "https://github.com/jmid/mutaml"
 bug-reports: "https://github.com/jmid/mutaml/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.18"}
   "ocaml" {>= "4.12.0"}
   "ppxlib" {>= "0.28.0"}
   "ppx_yojson_conv" {>= "v0.14.0"}
@@ -32,6 +32,7 @@ depends: [
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/jmid/mutaml.git"
+x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -46,4 +47,3 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-x-maintenance-intent: ["(latest)"]

--- a/mutaml.opam.template
+++ b/mutaml.opam.template
@@ -12,4 +12,3 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Since `dune.3.18` it supports generating `x-maintenance-intent` for the opam file:
https://github.com/ocaml/dune/blob/main/CHANGES.md#3180-2025-04-03
This allows us to eliminate a line from the `mutaml.opam.template` file again.

I also discovered that #43 mistakingly changed the `mutaml.opam` but not `dune-project` which 5df59f8 corrects.